### PR TITLE
Introduce shared design tokens, refactor components to use Theme tokens, and improve DesktopIcons drag/drop

### DIFF
--- a/docs/design-system-standardization-audit.md
+++ b/docs/design-system-standardization-audit.md
@@ -1,0 +1,79 @@
+# AstreaOS design-system standardization audit
+
+## Scope
+
+This pass reviewed the current design-token split and Settings UI consistency before any larger theme refactor. It intentionally avoids a risky global rewrite and favors additive compatibility tokens plus small shared-component cleanup.
+
+Reviewed areas:
+
+- `src/Quickshell/bar/Theme.qml`
+- `src/Core/components/theme/Theme.qml`
+- `src/Core/components/Theme.qml`
+- app-local `Theme.qml` files under `src/Apps/**`
+- Settings pages under `src/Apps/Settings/**`
+- reusable Settings/Core form components under `src/Core/components/form/**`
+
+## Theme architecture findings
+
+### Current theme/token files
+
+| File | Current responsibility | Notes |
+| --- | --- | --- |
+| `src/Core/components/theme/Theme.qml` | Persisted app UI theme state, Settings/app colors, typography, and now additive compatibility tokens for layout/motion/opacity. | Best candidate for the eventual global app design-token source because it already owns user theme persistence and is imported by Settings shared components. |
+| `src/Core/components/Theme.qml` | Compatibility wrapper around `components/theme/Theme.qml`. | Keep this wrapper so existing imports do not break while token names are consolidated. |
+| `src/Quickshell/bar/Theme.qml` | Shell/bar-specific colors, typography, spacing/radius/motion tokens, workspace values. | Should remain shell-local short term because the shell has different contrast, alpha, and layout constraints from app windows. Later it can alias a shared Core token module where values match. |
+| `src/Apps/Explorer/Theme.qml` | Explorer-specific color palette. | Largely color-only and app-specific; can stay local until Explorer is migrated onto shared app colors. |
+| `src/Apps/Weather/Theme.qml` | Weather-specific colors, font sizes, and card radius. | Contains one-off app typography and a larger `cardRadius: 18`; keep local until Weather receives a dedicated visual pass. |
+
+### Duplicate/conflicting tokens to unify later
+
+- **Font families:** Core uses `Inter`; Quickshell uses `Inter Variable`, `Inter Display`, and `Inter Regular`; several feature/app files still use literal `Inter` or Nerd Font strings. Recommendation: introduce `fontFamilyUi`, `fontFamilyDisplay`, `fontFamilyMono`, and `fontFamilyIcon` globally, then keep `fontFamily` as a compatibility alias.
+- **Corner radii:** Quickshell standardizes around `6/8/10/12/14`; Core shared Settings controls now expose `8/10/12`; Weather uses `18`. Recommendation: globalize semantic tokens (`radiusSmall`, `controlRadius`, `cardRadius`, `radiusLarge`) and allow app-specific hero/media radius overrides.
+- **Spacing:** Core/Settings pages use repeated `4/6/8/12/16/18/28`; Quickshell has a denser shell scale including `3/7/9/10/14/20`. Recommendation: globalize common page/control spacing in Core and keep shell-only micro offsets local.
+- **Motion:** Common Settings values are `100/120/150/200/250/300`; Quickshell also has shell-specific pulse/spin values. Recommendation: globalize short interaction durations (`animationMicro`, `animationFast`, `animationNormal`, `animationSlow`) and keep long-running/status animation durations component-local unless reused.
+- **Text sizes:** Core has app-window sizes (`9/10/11/12/13/15/16/20/22/24`); Quickshell bar uses compact shell sizes (`9/10/11/12/13/16/18`). Recommendation: keep separate app and shell typography scales for now, but align naming (`fontSizeBody`, `fontSizeCaption`, `fontSizeTitle`) through aliases.
+
+### Safe migration path
+
+1. Keep existing theme entry points and add compatibility aliases instead of renaming/removing tokens.
+2. Migrate shared components first (`SettingRow`, `FormCard`, `ToggleSwitch`, `SelectButton`, etc.) so pages inherit consistency without many page edits.
+3. Migrate Settings pages only where they duplicate shared component patterns.
+4. After shared components and Settings pages settle, consider a read-only global token singleton that both Core and Quickshell can import for values that truly match.
+5. Leave app-specific colors and hero component dimensions local until each app receives a dedicated visual QA pass.
+
+## Settings UI consistency audit
+
+### Highest priority safe fixes
+
+1. **Replace custom toggles with the shared `ToggleSwitch` where behavior matches.**
+   - `src/Apps/Settings/pages/display/Island.qml` and `src/Apps/Settings/pages/display/Display.qml` both define local switch visuals with the same `36x20` track and `14x14` thumb pattern already available in `src/Core/components/form/ToggleSwitch.qml`.
+   - Safe path: replace visuals only when the click/toggle behavior can be preserved exactly.
+
+2. **Use `FormCard` + `SettingRow` for option rows that already follow the standard label/control pattern.**
+   - Some Settings pages define ad-hoc cards/rows with duplicated `radius: 12`, `spacing: 8/10/12`, and `duration: 150` values.
+   - Safe path: migrate one page section at a time, starting with rows that have no custom drag/preview behavior.
+
+3. **Standardize card and row radii through Core theme tokens.**
+   - Shared form components now use `Theme.cardRadius`, `Theme.controlRadius`, and `Theme.cornerRadiusSmall`.
+   - Safe path: update page-local `radius: 12/10/8` only where the component is clearly a normal card, control, or row hover background.
+
+4. **Normalize section spacing through `ScrollPage`, `SectionHeader`, and shared spacing tokens.**
+   - Settings pages mix `spacing: 4/6/8/10/12/14/16` and margins like `28` directly.
+   - Safe path: prefer `ScrollPage.contentMargins`, `Theme.pageMargin`, and `Theme.spacing*` aliases instead of changing layout structure.
+
+5. **Normalize labels/subtitles/disabled states.**
+   - Shared rows use Core text colors, font sizes, and opacity tokens; some page-local labels use hardcoded `#ffffff`, inline alpha values, or custom font sizes.
+   - Safe path: use Core text tokens (`textPrimary`, `textSecondary`, `opacityDisabled`, `opacitySecondary`) in local custom controls before replacing the controls themselves.
+
+### Medium priority fixes
+
+- Move recurring chip/button styles in personalization and display pages into small reusable components or extend `SelectButton` where behavior matches.
+- Audit pages using direct icon font names and decide whether an explicit `fontFamilyIcon` token should replace literal Nerd Font strings.
+- Align Settings page animation durations with Core motion tokens after the shared components are stable.
+
+### Should remain local for now
+
+- Preview canvases and monitor layout visuals in Display settings.
+- Wallpaper/lockscreen preview-specific dimensions.
+- App-specific status cards with unique data visualization needs.
+- Long-running progress/spinner timings that communicate state rather than ordinary UI interaction.

--- a/src/Core/components/form/FormCard.qml
+++ b/src/Core/components/form/FormCard.qml
@@ -5,7 +5,7 @@ import ".." as Components
 Rectangle {
     id: cardRoot
     Layout.fillWidth: true
-    radius: 12
+    radius: Components.Theme.cardRadius
     color: Components.Theme.cardBg
     border.width: 1
     border.color: Components.Theme.cardBorder

--- a/src/Core/components/form/IconListRow.qml
+++ b/src/Core/components/form/IconListRow.qml
@@ -27,16 +27,16 @@ Item {
     Rectangle {
         anchors.fill: parent
         color: rowArea.containsMouse && rowRoot.interactive ? Qt.rgba(1, 1, 1, 0.04) : "transparent"
-        Behavior on color { ColorAnimation { duration: 150 } }
-        radius: 8
-        anchors.margins: 2
+        Behavior on color { ColorAnimation { duration: Components.Theme.animationFast } }
+        radius: Components.Theme.cornerRadiusSmall
+        anchors.margins: Components.Theme.spacingTiny
     }
 
     RowLayout {
         anchors.fill: parent
-        anchors.leftMargin: 16
-        anchors.rightMargin: 16
-        spacing: 12
+        anchors.leftMargin: Components.Theme.spacingLarge
+        anchors.rightMargin: Components.Theme.spacingLarge
+        spacing: Components.Theme.spacingMedium
 
         // Optional Left Icon
         Text {
@@ -82,7 +82,7 @@ Item {
             font.family: "JetBrainsMono Nerd Font"
             font.pixelSize: 14
             color: Components.Theme.textSecondary
-            opacity: 0.3
+            opacity: Components.Theme.opacityDisabled
         }
     }
     
@@ -92,10 +92,10 @@ Item {
         anchors.bottom: parent.bottom
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.leftMargin: rowRoot.iconText !== "" ? 44 : 16
+        anchors.leftMargin: rowRoot.iconText !== "" ? 44 : Components.Theme.spacingLarge
         height: 1
         color: Components.Theme.cardBorder
-        opacity: 0.3
+        opacity: Components.Theme.opacityDisabled
     }
     
     MouseArea {

--- a/src/Core/components/form/ScrollPage.qml
+++ b/src/Core/components/form/ScrollPage.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import ".." as Components
 
 /**
  * ScrollPage - A standardized scrollable container for settings pages.
@@ -13,7 +14,7 @@ ScrollView {
     clip: true
     
     // Configurable properties
-    property real contentMargins: 28
+    property real contentMargins: Components.Theme.pageMargin
     property real maxWidth:       800  // Maximum width for the content area
     property real scrollGap:      14
     

--- a/src/Core/components/form/SectionHeader.qml
+++ b/src/Core/components/form/SectionHeader.qml
@@ -13,7 +13,7 @@ Item {
 
     RowLayout {
         id: layout
-        spacing: 8
+        spacing: Components.Theme.spacing
         anchors.fill: parent
 
         Text {

--- a/src/Core/components/form/SelectButton.qml
+++ b/src/Core/components/form/SelectButton.qml
@@ -27,27 +27,27 @@ Item {
 
     readonly property int maxVisible: 5
     readonly property int itemH:      36
-    readonly property int popupPad:   6
+    readonly property int popupPad:   Components.Theme.spacingSmall
     readonly property int listH: Math.min(sel.options.length, sel.maxVisible) * sel.itemH + popupPad * 2
 
     // ── Main Button ───────────────────────────────────────────────────────
     Rectangle {
         id: btnRect
         anchors.fill: parent
-        radius: 10
+        radius: Components.Theme.controlRadius
         color: btnArea.containsMouse ? Qt.rgba(1, 1, 1, 0.09) : sel.cardBg
         border.width: 1
         border.color: (dropdown.visible || btnArea.pressed) ? sel.accent : sel.cardBorder
         
         // Premium Micro-animations
         scale: btnArea.pressed ? 0.96 : (dropdown.visible ? 0.98 : 1.0)
-        Behavior on scale { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
-        Behavior on color { ColorAnimation { duration: 200 } }
-        Behavior on border.color { ColorAnimation { duration: 200 } }
+        Behavior on scale { NumberAnimation { duration: Components.Theme.animationFast; easing.type: Easing.OutCubic } }
+        Behavior on color { ColorAnimation { duration: Components.Theme.animationNormal } }
+        Behavior on border.color { ColorAnimation { duration: Components.Theme.animationNormal } }
 
         RowLayout {
-            anchors { fill: parent; leftMargin: 14; rightMargin: 12 }
-            spacing: 8
+            anchors { fill: parent; leftMargin: Components.Theme.spacingMedium; rightMargin: Components.Theme.spacingMedium }
+            spacing: Components.Theme.spacing
             Text {
                 Layout.fillWidth: true
                 text: sel.label
@@ -56,18 +56,18 @@ Item {
                 font.pixelSize: Components.Theme.fontSizeNormal
                 font.weight: Components.Theme.fontWeightMedium
                 elide: Text.ElideRight
-                Behavior on color { ColorAnimation { duration: 150 } }
+                Behavior on color { ColorAnimation { duration: Components.Theme.animationFast } }
             }
             Text {
                 visible: !sel.isButton
                 text: dropdown.visible ? "⌃" : "⌄"
                 color: dropdown.visible ? sel.accent : sel.textSecondary
                 font.pixelSize: Components.Theme.fontSizeNormal
-                Behavior on color { ColorAnimation { duration: 150 } }
+                Behavior on color { ColorAnimation { duration: Components.Theme.animationFast } }
                 
                 // Add a subtle rotation instead of snapping character
                 rotation: dropdown.visible ? 180 : 0
-                Behavior on rotation { NumberAnimation { duration: 200; easing.type: Easing.OutBack } }
+                Behavior on rotation { NumberAnimation { duration: Components.Theme.animationNormal; easing.type: Easing.OutBack } }
             }
             Text {
                 visible: sel.isButton
@@ -75,7 +75,7 @@ Item {
                 font.family: "JetBrainsMono Nerd Font"
                 color: btnArea.containsMouse ? sel.accent : sel.textSecondary
                 font.pixelSize: Components.Theme.fontSizeNormal
-                Behavior on color { ColorAnimation { duration: 150 } }
+                Behavior on color { ColorAnimation { duration: Components.Theme.animationFast } }
             }
         }
 
@@ -107,7 +107,7 @@ Item {
 
         background: Rectangle {
             id: popupBgRect
-            radius: 12
+            radius: Components.Theme.cornerRadiusLarge
             color: sel.popupBg
             border.width: 1
             border.color: Qt.rgba(1, 1, 1, 0.1) // slightly brighter than cardBorder for elevation
@@ -126,16 +126,16 @@ Item {
         // Extremely snappy/premium enter transition
         enter: Transition {
             ParallelAnimation {
-                NumberAnimation { property: "opacity"; from: 0; to: 1; duration: 200; easing.type: Easing.OutCubic }
-                NumberAnimation { property: "scale"; from: 0.9; to: 1.0; duration: 300; easing.type: Easing.OutElastic; easing.amplitude: 0.8 }
-                NumberAnimation { property: "y"; from: sel.popupDirection === "up" ? -(sel.listH + 1) : sel.height - 5; to: sel.popupDirection === "up" ? -(sel.listH + 6) : sel.height + 6; duration: 250; easing.type: Easing.OutCubic }
+                NumberAnimation { property: "opacity"; from: 0; to: 1; duration: Components.Theme.animationNormal; easing.type: Easing.OutCubic }
+                NumberAnimation { property: "scale"; from: 0.9; to: 1.0; duration: Components.Theme.animationPopover; easing.type: Easing.OutElastic; easing.amplitude: 0.8 }
+                NumberAnimation { property: "y"; from: sel.popupDirection === "up" ? -(sel.listH + 1) : sel.height - 5; to: sel.popupDirection === "up" ? -(sel.listH + 6) : sel.height + 6; duration: Components.Theme.animationSlow; easing.type: Easing.OutCubic }
             }
         }
         exit: Transition {
             ParallelAnimation {
-                NumberAnimation { property: "opacity"; from: 1; to: 0; duration: 150; easing.type: Easing.InCubic }
-                NumberAnimation { property: "scale"; from: 1.0; to: 0.95; duration: 150; easing.type: Easing.InCubic }
-                NumberAnimation { property: "y"; from: sel.popupDirection === "up" ? -(sel.listH + 6) : sel.height + 6; to: sel.popupDirection === "up" ? -(sel.listH + 2) : sel.height + 2; duration: 150; easing.type: Easing.InCubic }
+                NumberAnimation { property: "opacity"; from: 1; to: 0; duration: Components.Theme.animationFast; easing.type: Easing.InCubic }
+                NumberAnimation { property: "scale"; from: 1.0; to: 0.95; duration: Components.Theme.animationFast; easing.type: Easing.InCubic }
+                NumberAnimation { property: "y"; from: sel.popupDirection === "up" ? -(sel.listH + 6) : sel.height + 6; to: sel.popupDirection === "up" ? -(sel.listH + 2) : sel.height + 2; duration: Components.Theme.animationFast; easing.type: Easing.InCubic }
             }
         }
 
@@ -143,7 +143,7 @@ Item {
             id: listView
             clip: true
             model: sel.options
-            spacing: 4
+            spacing: Components.Theme.spacingMicro
             boundsBehavior: Flickable.StopAtBounds
             onVisibleChanged: if (visible && sel.selectedIndex >= 0) positionViewAtIndex(sel.selectedIndex, ListView.Contain)
 
@@ -155,18 +155,18 @@ Item {
                 readonly property bool active: sel.selectedIndex === index
                 width: listView.width
                 height: sel.itemH
-                radius: 8
+                radius: Components.Theme.cornerRadiusSmall
                 color: rowArea.pressed 
                        ? Qt.rgba(sel.accent.r, sel.accent.g, sel.accent.b, 0.25)
                        : (active ? Qt.rgba(sel.accent.r, sel.accent.g, sel.accent.b, 0.15) 
                                  : (rowArea.containsMouse ? Qt.rgba(1, 1, 1, 0.08) : "transparent"))
                 
                 scale: rowArea.pressed ? 0.97 : 1.0
-                Behavior on scale { NumberAnimation { duration: 100 } }
-                Behavior on color { ColorAnimation { duration: 150 } }
+                Behavior on scale { NumberAnimation { duration: Components.Theme.animationMicro } }
+                Behavior on color { ColorAnimation { duration: Components.Theme.animationFast } }
 
                 RowLayout {
-                    anchors { fill: parent; leftMargin: 12; rightMargin: 12 }
+                    anchors { fill: parent; leftMargin: Components.Theme.spacingMedium; rightMargin: Components.Theme.spacingMedium }
                     Text {
                         Layout.fillWidth: true
                         text: modelData
@@ -174,7 +174,7 @@ Item {
                         font.family: Components.Theme.fontFamily
                         font.pixelSize: Components.Theme.fontSizeNormal
                         font.weight: active ? Components.Theme.fontWeightDemiBold : Components.Theme.fontWeightMedium
-                        Behavior on color { ColorAnimation { duration: 150 } }
+                        Behavior on color { ColorAnimation { duration: Components.Theme.animationFast } }
                     }
                     Text {
                         visible: active

--- a/src/Core/components/form/SettingRow.qml
+++ b/src/Core/components/form/SettingRow.qml
@@ -21,19 +21,19 @@ Item {
     // Interactive subtle hover background
     Rectangle {
         id: bgHighlight
-        anchors { fill: parent; leftMargin: 4; rightMargin: 4; topMargin: 2; bottomMargin: 2 }
-        radius: 10
+        anchors { fill: parent; leftMargin: Components.Theme.spacingMicro; rightMargin: Components.Theme.spacingMicro; topMargin: Components.Theme.spacingTiny; bottomMargin: Components.Theme.spacingTiny }
+        radius: Components.Theme.controlRadius
         color: rowArea.containsMouse ? sr.rowHoverBg : "transparent"
-        Behavior on color { ColorAnimation { duration: 250; easing.type: Easing.OutQuart } }
+        Behavior on color { ColorAnimation { duration: Components.Theme.animationSlow; easing.type: Easing.OutQuart } }
     }
 
     RowLayout {
-        anchors { fill: parent; leftMargin: 18; rightMargin: 18 }
-        spacing: 16
+        anchors { fill: parent; leftMargin: Components.Theme.spacingXLarge; rightMargin: Components.Theme.spacingXLarge }
+        spacing: Components.Theme.spacingLarge
 
         ColumnLayout {
             Layout.fillWidth: true
-            spacing: 4
+            spacing: Components.Theme.spacingMicro
             
             Text { 
                 text: sr.label; 
@@ -59,13 +59,13 @@ Item {
             implicitHeight: children.length > 0 ? children[0].implicitHeight : 0
             Layout.alignment: Qt.AlignVCenter | Qt.AlignRight
             scale: rowArea.pressed ? 0.98 : 1.0
-            Behavior on scale { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
+            Behavior on scale { NumberAnimation { duration: Components.Theme.animationFast; easing.type: Easing.OutCubic } }
         }
     }
 
     Rectangle {
         visible: !sr.isLast
-        anchors { bottom: parent.bottom; left: parent.left; right: parent.right; leftMargin: 18 }
+        anchors { bottom: parent.bottom; left: parent.left; right: parent.right; leftMargin: Components.Theme.spacingXLarge }
         height: 1; 
         color: sr.cardBorder
     }

--- a/src/Core/components/form/ToggleSwitch.qml
+++ b/src/Core/components/form/ToggleSwitch.qml
@@ -5,20 +5,20 @@ Rectangle {
     id: toggle
     width: 36
     height: 20
-    radius: 10
+    radius: Components.Theme.controlRadius
     property bool checked: false
     signal toggled()
     color: checked ? Components.Theme.accent : Qt.rgba(1, 1, 1, 0.18)
-    Behavior on color { ColorAnimation { duration: 150 } }
+    Behavior on color { ColorAnimation { duration: Components.Theme.animationFast } }
 
     Rectangle {
         width: 14
         height: 14
-        radius: 7
+        radius: height / 2
         color: "#ffffff"
         anchors.verticalCenter: parent.verticalCenter
         x: toggle.checked ? parent.width - width - 3 : 3
-        Behavior on x { NumberAnimation { duration: 150; easing.type: Easing.OutCubic } }
+        Behavior on x { NumberAnimation { duration: Components.Theme.animationFast; easing.type: Easing.OutCubic } }
     }
 
     MouseArea {

--- a/src/Core/components/theme/Theme.qml
+++ b/src/Core/components/theme/Theme.qml
@@ -79,6 +79,43 @@ Item {
 
     readonly property real trackingHeader:    0
 
+    // ── Layout tokens ─────────────────────────────────────────────────────
+    // Authority note: Core Theme owns app-window and Settings tokens. Quickshell
+    // shell surfaces currently keep a separate Theme with tighter bar-specific
+    // values; do not assume matching names imply matching values yet.
+    // Keep these additive for compatibility while Settings pages migrate away
+    // from one-off literals in small, reviewable passes.
+    readonly property real radiusSmall: 8
+    readonly property real radiusMedium: 10
+    readonly property real radiusLarge: 12
+    readonly property real cornerRadiusSmall: radiusSmall
+    readonly property real cornerRadius: radiusMedium
+    readonly property real cornerRadiusLarge: radiusLarge
+    readonly property real cardRadius: radiusLarge
+    readonly property real controlRadius: radiusMedium
+
+    readonly property real spacingTiny: 2
+    readonly property real spacingMicro: 4
+    readonly property real spacingSmall: 6
+    readonly property real spacing: 8
+    readonly property real spacingMedium: 12
+    readonly property real spacingLarge: 16
+    readonly property real spacingXLarge: 18
+    readonly property real pageMargin: 28
+
+    // ── Motion tokens ─────────────────────────────────────────────────────
+    readonly property int animationMicro: 100
+    readonly property int animationQuick: 120
+    readonly property int animationFast: 150
+    readonly property int animationNormal: 200
+    readonly property int animationSlow: 250
+    readonly property int animationPopover: 300
+
+    // ── Opacity tokens ────────────────────────────────────────────────────
+    readonly property real opacityDisabled: 0.3
+    readonly property real opacitySecondary: 0.5
+    readonly property real opacityMuted: 0.6
+
     // ── Theme ─────────────────────────────────────────────────────────────
     readonly property color accent:        accentHex
     readonly property color textPrimary:   themeMode === 1 ? "#111111" : "#ffffff"

--- a/src/Quickshell/bar/Theme.qml
+++ b/src/Quickshell/bar/Theme.qml
@@ -29,9 +29,51 @@ QtObject {
     readonly property color accent: "#34b7f1" 
 
     // --- Layout & Spacing ---
+    // Authority note: this Theme is currently scoped to Quickshell shell surfaces
+    // (bar, popups, desktop overlays). Core/components/theme/Theme.qml remains
+    // authoritative for app-window and Settings UI until a shared token module exists.
     readonly property real radiusLarge:  14
     readonly property real radiusMedium: 8
     readonly property real radiusSmall:  6
+    readonly property real cornerRadiusSmall: radiusSmall
+    readonly property real cornerRadius: radiusMedium
+    readonly property real cornerRadiusLarge: radiusLarge
+    readonly property real controlRadius: 10
+    readonly property real tileRadius: 12
+    readonly property real pillRadius: 999
+
+    readonly property real spacingTiny: 3
+    readonly property real spacingMicro: 4
+    readonly property real spacingSmall: 6
+    readonly property real spacingInset: 7
+    readonly property real spacing: 8
+    readonly property real spacingMedium: 10
+    readonly property real spacingControlGap: 9
+    readonly property real spacingLarge: 12
+    readonly property real spacingXLarge: 14
+    readonly property real spacingXXLarge: 20
+    readonly property real spacingContainer: 16
+
+    // --- Motion ---
+    readonly property int animationSlider: 60
+    readonly property int animationInstant: 90
+    readonly property int animationMicro: 100
+    readonly property int animationQuick: 120
+    readonly property int animationSubtle: 130
+    readonly property int animationHover: 140
+    readonly property int animationFast: 150
+    readonly property int animationStandard: 160
+    readonly property int animationNormal: 200
+    readonly property int animationSlow: 400
+    readonly property int animationPulse: 900
+    readonly property int animationSpin: 1200
+
+    // --- Opacity ---
+    readonly property real opacityMuted: 0.80
+    readonly property real opacitySecondary: 0.85
+    readonly property real opacitySubtle: 0.86
+    readonly property real opacityEmphasis: 0.90
+    readonly property real opacityDragging: 0.94
     
     // --- Typography ---
     readonly property string fontFamily: "Inter Variable"

--- a/src/Quickshell/bar/ui/BarContent.qml
+++ b/src/Quickshell/bar/ui/BarContent.qml
@@ -88,7 +88,7 @@ Item {
         property: "opacity"
         from: 0
         to: 1
-        duration: 400
+        duration: Theme.animationSlow
         easing.type: Easing.OutCubic
     }
 
@@ -109,13 +109,13 @@ Item {
             border.width: 1
             border.color: leftHover.hovered ? Theme.barBorderHover : Theme.border
 
-            Behavior on border.color { ColorAnimation { duration: 200 } }
+            Behavior on border.color { ColorAnimation { duration: Theme.animationNormal } }
         }
 
         Row {
             id: leftRow
             anchors.centerIn: parent
-            spacing: 8
+            spacing: Theme.spacing
 
             Rectangle {
                 id: logoButton
@@ -131,7 +131,7 @@ Item {
                     width: 18
                     height: 18
                     fillMode: Image.PreserveAspectFit
-                    opacity: 0.80
+                    opacity: Theme.opacityMuted
                 }
 
                 MouseArea {
@@ -170,7 +170,7 @@ Item {
             border.width: 1
             border.color: rightHover.hovered ? Theme.barBorderHover : Theme.border
 
-            Behavior on border.color { ColorAnimation { duration: 200 } }
+            Behavior on border.color { ColorAnimation { duration: Theme.animationNormal } }
         }
 
         Row {
@@ -252,8 +252,8 @@ Item {
 
                     Behavior on text {
                         SequentialAnimation {
-                            NumberAnimation { target: dateLabel; property: "opacity"; to: 0; duration: 120 }
-                            NumberAnimation { target: dateLabel; property: "opacity"; to: 1; duration: 120 }
+                            NumberAnimation { target: dateLabel; property: "opacity"; to: 0; duration: Theme.animationQuick }
+                            NumberAnimation { target: dateLabel; property: "opacity"; to: 1; duration: Theme.animationQuick }
                         }
                     }
                 }
@@ -279,8 +279,8 @@ Item {
 
                     Behavior on text {
                         SequentialAnimation {
-                            NumberAnimation { target: clockLabel; property: "opacity"; to: 0; duration: 150; easing.type: Easing.InQuad }
-                            NumberAnimation { target: clockLabel; property: "opacity"; to: 1; duration: 200; easing.type: Easing.OutQuad }
+                            NumberAnimation { target: clockLabel; property: "opacity"; to: 0; duration: Theme.animationFast; easing.type: Easing.InQuad }
+                            NumberAnimation { target: clockLabel; property: "opacity"; to: 1; duration: Theme.animationNormal; easing.type: Easing.OutQuad }
                         }
                     }
                 }

--- a/src/Quickshell/bar/ui/components/astrea/MenuItem.qml
+++ b/src/Quickshell/bar/ui/components/astrea/MenuItem.qml
@@ -13,18 +13,18 @@ Rectangle {
     height: 36
     radius: Theme.radiusMedium
     color:  _mouse.containsMouse ? Theme.separator : "transparent"
-    Behavior on color { ColorAnimation { duration: 150 } }
+    Behavior on color { ColorAnimation { duration: Theme.animationFast } }
 
     Row {
         anchors { fill: parent; leftMargin: 12 }
-        spacing: 12
+        spacing: Theme.spacingLarge
 
         Text {
             anchors.verticalCenter: parent.verticalCenter
             text:  root.icon
             color: _mouse.containsMouse ? Theme.iconActive : Theme.iconMain
             font.pixelSize: Theme.fontSizeIcon
-            Behavior on color { ColorAnimation { duration: 150 } }
+            Behavior on color { ColorAnimation { duration: Theme.animationFast } }
         }
 
         Text {
@@ -32,7 +32,7 @@ Rectangle {
             text:  root.text
             color: _mouse.containsMouse ? Theme.textActive : Qt.rgba(1, 1, 1, 0.8)
             font { family: Theme.fontFamily; pixelSize: Theme.fontSizeBody; weight: Font.Medium }
-            Behavior on color { ColorAnimation { duration: 150 } }
+            Behavior on color { ColorAnimation { duration: Theme.animationFast } }
         }
     }
 

--- a/src/Quickshell/bar/ui/components/bluetooth/BluetoothIndicator.qml
+++ b/src/Quickshell/bar/ui/components/bluetooth/BluetoothIndicator.qml
@@ -44,13 +44,13 @@ SystemComponents.IndicatorButton {
             SequentialAnimation on opacity {
                 running: root.isScanning
                 loops:   Animation.Infinite
-                NumberAnimation { to: 0;   duration: 900 }
+                NumberAnimation { to: 0;   duration: Theme.animationPulse }
                 NumberAnimation { to: 0.9; duration: 0   }
             }
             SequentialAnimation on scale {
                 running: root.isScanning
                 loops:   Animation.Infinite
-                NumberAnimation { to: 1.8; duration: 900; easing.type: Easing.OutCubic }
+                NumberAnimation { to: 1.8; duration: Theme.animationPulse; easing.type: Easing.OutCubic }
                 NumberAnimation { to: 1.0; duration: 0   }
             }
         }
@@ -62,7 +62,7 @@ SystemComponents.IndicatorButton {
             color: !root.btOn ? Theme.iconMuted
                  : root.connectedCount > 0 ? Theme.iconAccent
                  : Theme.iconMain
-            Behavior on color { ColorAnimation { duration: 150 } }
+            Behavior on color { ColorAnimation { duration: Theme.animationFast } }
         }
     }
 

--- a/src/Quickshell/bar/ui/components/bluetooth/BluetoothPopup.qml
+++ b/src/Quickshell/bar/ui/components/bluetooth/BluetoothPopup.qml
@@ -62,27 +62,27 @@ SystemComponents.TopbarPopup {
         trailingWidth: 44
         Rectangle {
             anchors.centerIn: parent
-            width: 44; height: 24; radius: 12
+            width: 44; height: 24; radius: height / 2
             color: root.btOn
                 ? Qt.rgba(0.20, 0.60, 1.0, 0.30)
                 : (powerArea.containsMouse && !root.powerPending ? Theme.separator : Qt.rgba(1, 1, 1, 0.07))
             border { width: 1; color: root.btOn ? Qt.rgba(0.20, 0.60, 1.0, 0.50) : Qt.rgba(1, 1, 1, 0.08) }
             opacity: root.powerPending ? 0.55 : 1.0
-            Behavior on color        { ColorAnimation { duration: 150 } }
-            Behavior on border.color { ColorAnimation { duration: 150 } }
-            Behavior on opacity      { NumberAnimation { duration: 120 } }
+            Behavior on color        { ColorAnimation { duration: Theme.animationFast } }
+            Behavior on border.color { ColorAnimation { duration: Theme.animationFast } }
+            Behavior on opacity      { NumberAnimation { duration: Theme.animationQuick } }
 
             Text {
                 anchors.centerIn: parent
                 text:  root.powerPending ? "󰑐" : "󰂯"
                 color: root.btOn ? Theme.iconAccent : Theme.iconMuted
                 font { family: Theme.fontFamily; pixelSize: Theme.fontSizeBody }
-                Behavior on color { ColorAnimation { duration: 150 } }
+                Behavior on color { ColorAnimation { duration: Theme.animationFast } }
                 RotationAnimation on rotation {
                     running: root.powerPending
                     from: 0
                     to: 360
-                    duration: 900
+                    duration: Theme.animationPulse
                     loops: Animation.Infinite
                 }
             }
@@ -138,15 +138,15 @@ SystemComponents.TopbarPopup {
 
     Rectangle {
         visible: root.btOn
-        width: parent.width; height: 32; radius: 10
+        width: parent.width; height: 32; radius: Theme.controlRadius
         color: root.scanning
             ? Qt.rgba(0.20, 0.60, 1.0, 0.10)
             : (scanBtnArea.containsMouse ? Theme.separator : "transparent")
         border { width: root.scanning ? 1 : 0; color: Qt.rgba(0.20, 0.60, 1.0, 0.25) }
-        Behavior on color { ColorAnimation { duration: 150 } }
+        Behavior on color { ColorAnimation { duration: Theme.animationFast } }
 
         Row {
-            anchors.centerIn: parent; spacing: 6
+            anchors.centerIn: parent; spacing: Theme.spacingSmall
 
             Text {
                 anchors.verticalCenter: parent.verticalCenter
@@ -156,7 +156,7 @@ SystemComponents.TopbarPopup {
                 RotationAnimation on rotation {
                     running: root.scanning
                     from: 0; to: 360
-                    duration: 1200; loops: Animation.Infinite
+                    duration: Theme.animationSpin; loops: Animation.Infinite
                 }
             }
 
@@ -209,7 +209,7 @@ SystemComponents.TopbarPopup {
                 opacity:     0
 
                 Component.onCompleted: opacity = 1
-                Behavior on opacity { NumberAnimation { duration: 200; easing.type: Easing.OutCubic } }
+                Behavior on opacity { NumberAnimation { duration: Theme.animationNormal; easing.type: Easing.OutCubic } }
 
                 onActivated: {
                     if (!root.btProcess) return
@@ -224,12 +224,12 @@ SystemComponents.TopbarPopup {
     Rectangle { width: parent.width; height: 1; color: Theme.separator }
 
     Rectangle {
-        width: parent.width; height: 32; radius: 10
+        width: parent.width; height: 32; radius: Theme.controlRadius
         color: settingsArea.containsMouse ? Theme.separator : "transparent"
-        Behavior on color { ColorAnimation { duration: 150 } }
+        Behavior on color { ColorAnimation { duration: Theme.animationFast } }
 
         Row {
-            anchors.centerIn: parent; spacing: 6
+            anchors.centerIn: parent; spacing: Theme.spacingSmall
             Text {
                 anchors.verticalCenter: parent.verticalCenter
                 text: "󰒓"; color: Theme.textSecondary; font { family: Theme.fontFamily; pixelSize: Theme.fontSizeIcon }
@@ -262,25 +262,25 @@ SystemComponents.TopbarPopup {
         property bool   isPaired:    true
         signal activated()
 
-        height: 38; radius: 10
+        height: 38; radius: Theme.controlRadius
 
         color: isConnected
             ? Qt.rgba(0.20, 0.60, 1.0, 0.12)
             : (rowHover.containsMouse ? Theme.separator : "transparent")
         border { width: 1; color: isConnected ? Qt.rgba(0.20, 0.60, 1.0, 0.25) : "transparent" }
-        Behavior on color        { ColorAnimation { duration: 150 } }
-        Behavior on border.color { ColorAnimation { duration: 150 } }
+        Behavior on color        { ColorAnimation { duration: Theme.animationFast } }
+        Behavior on border.color { ColorAnimation { duration: Theme.animationFast } }
 
         Row {
-            anchors { fill: parent; leftMargin: 10; rightMargin: 10 }
-            spacing: 10
+            anchors { fill: parent; leftMargin: Theme.spacingMedium; rightMargin: Theme.spacingMedium }
+            spacing: Theme.spacingMedium
 
             Text {
                 anchors.verticalCenter: parent.verticalCenter
                 text:  rowRoot.isPaired ? "󰂱" : "󰂴"
                 color: rowRoot.isConnected ? Theme.iconAccent : Theme.iconMain
                 font { family: Theme.fontFamily; pixelSize: Theme.fontSizeIcon }
-                Behavior on color { ColorAnimation { duration: 150 } }
+                Behavior on color { ColorAnimation { duration: Theme.animationFast } }
             }
 
             Text {
@@ -296,13 +296,13 @@ SystemComponents.TopbarPopup {
                     pixelSize: Theme.fontSizeBody
                     weight:    rowRoot.isConnected ? Font.DemiBold : Font.Normal
                 }
-                Behavior on color { ColorAnimation { duration: 150 } }
+                Behavior on color { ColorAnimation { duration: Theme.animationFast } }
             }
 
             Rectangle {
                 visible: rowRoot.isConnected
                 anchors.verticalCenter: parent.verticalCenter
-                width: 60; height: 18; radius: 9
+                width: 60; height: 18; radius: height / 2
                 color: Qt.rgba(0.20, 0.60, 1.0, 0.20)
                 Text {
                     anchors.centerIn: parent
@@ -314,17 +314,17 @@ SystemComponents.TopbarPopup {
             Rectangle {
                 visible: !rowRoot.isPaired
                 anchors.verticalCenter: parent.verticalCenter
-                width: 44; height: 18; radius: 9
+                width: 44; height: 18; radius: height / 2
                 color: rowHover.containsMouse
                     ? Qt.rgba(0.20, 0.60, 1.0, 0.25)
                     : Qt.rgba(1, 1, 1, 0.07)
-                Behavior on color { ColorAnimation { duration: 150 } }
+                Behavior on color { ColorAnimation { duration: Theme.animationFast } }
                 Text {
                     anchors.centerIn: parent
                     text:  "pair"
                     color: rowHover.containsMouse ? Theme.iconAccent : Qt.rgba(1, 1, 1, 0.40)
                     font { family: Theme.fontFamily; pixelSize: Theme.fontSizeMicro; weight: Font.DemiBold; letterSpacing: 0.3 }
-                    Behavior on color { ColorAnimation { duration: 150 } }
+                    Behavior on color { ColorAnimation { duration: Theme.animationFast } }
                 }
             }
         }

--- a/src/Quickshell/bar/ui/components/controlcenter/ControlCenterPopup.qml
+++ b/src/Quickshell/bar/ui/components/controlcenter/ControlCenterPopup.qml
@@ -47,12 +47,12 @@ SystemComponents.TopbarPopup {
     signal muteChangeHandled(bool muted)
 
     popupWidth: 356
-    cardPadding: 16
-    contentSpacing: 12
+    cardPadding: Theme.spacingContainer
+    contentSpacing: Theme.spacingLarge
     backgroundColor: control.popupGlass
     washColor: control.popupWash
     borderColor: control.popupBorder
-    floatingAccessoryGap: 8
+    floatingAccessoryGap: Theme.spacing
     floatingAccessoryRightMargin: 2
     floatingAccessory: Component {
         Rectangle {
@@ -60,7 +60,7 @@ SystemComponents.TopbarPopup {
 
             implicitWidth: customizeRow.implicitWidth + 22
             implicitHeight: 30
-            radius: 15
+            radius: height / 2
             color: control.customizeMode
                 ? Qt.rgba(Theme.accent.r, Theme.accent.g, Theme.accent.b, customizeFloatArea.containsMouse ? 0.34 : 0.26)
                 : (customizeFloatArea.containsMouse ? Theme.surface : Theme.background)
@@ -69,13 +69,13 @@ SystemComponents.TopbarPopup {
                 ? Qt.rgba(Theme.accent.r, Theme.accent.g, Theme.accent.b, 0.52)
                 : Theme.border
 
-            Behavior on color { ColorAnimation { duration: 140 } }
-            Behavior on border.color { ColorAnimation { duration: 140 } }
+            Behavior on color { ColorAnimation { duration: Theme.animationHover } }
+            Behavior on border.color { ColorAnimation { duration: Theme.animationHover } }
 
             Row {
                 id: customizeRow
                 anchors.centerIn: parent
-                spacing: 6
+                spacing: Theme.spacingSmall
 
                 Text {
                     anchors.verticalCenter: parent.verticalCenter
@@ -399,7 +399,7 @@ SystemComponents.TopbarPopup {
             anchors.verticalCenter: parent.verticalCenter
             width: 30
             height: 30
-            radius: 15
+            radius: height / 2
             color: Theme.surface
 
             Text {
@@ -453,7 +453,7 @@ SystemComponents.TopbarPopup {
         Item {
             Row {
                 anchors.fill: parent
-                spacing: 10
+                spacing: Theme.spacingMedium
 
                 ConnectivityCard {
                     width: (parent.width - parent.spacing) / 2
@@ -525,25 +525,25 @@ SystemComponents.TopbarPopup {
         border.width: 1
         border.color: active ? Theme.barBorderHover : Theme.border
 
-        Behavior on color { ColorAnimation { duration: 160 } }
-        Behavior on border.color { ColorAnimation { duration: 160 } }
+        Behavior on color { ColorAnimation { duration: Theme.animationStandard } }
+        Behavior on border.color { ColorAnimation { duration: Theme.animationStandard } }
 
         Rectangle {
             id: mediaArt
             anchors.left: parent.left
             anchors.top: parent.top
-            anchors.leftMargin: 12
-            anchors.topMargin: 12
+            anchors.leftMargin: Theme.spacingLarge
+            anchors.topMargin: Theme.spacingLarge
             width: 46
             height: 46
-            radius: 12
+            radius: Theme.tileRadius
             clip: true
             color: Theme.surface
 
             Rectangle {
                 id: mediaArtMask
                 anchors.fill: parent
-                radius: 12
+                radius: Theme.tileRadius
                 visible: false
             }
 
@@ -573,9 +573,9 @@ SystemComponents.TopbarPopup {
             anchors.left: parent.left
             anchors.right: parent.right
             anchors.top: mediaArt.bottom
-            anchors.leftMargin: 14
-            anchors.rightMargin: 12
-            anchors.topMargin: 14
+            anchors.leftMargin: Theme.spacingXLarge
+            anchors.rightMargin: Theme.spacingLarge
+            anchors.topMargin: Theme.spacingXLarge
             spacing: 3
 
             Text {
@@ -592,7 +592,7 @@ SystemComponents.TopbarPopup {
                 text: mediaCard.artist
                 color: Theme.textSecondary
                 elide: Text.ElideRight
-                opacity: 0.9
+                opacity: Theme.opacityEmphasis
                 maximumLineCount: 1
                 font { family: Theme.fontFamily; pixelSize: Theme.fontSizeBody; weight: Font.Medium }
             }
@@ -602,8 +602,8 @@ SystemComponents.TopbarPopup {
             anchors.left: parent.left
             anchors.bottom: parent.bottom
             anchors.leftMargin: 15
-            anchors.bottomMargin: 14
-            spacing: 14
+            anchors.bottomMargin: Theme.spacingXLarge
+            spacing: Theme.spacingXLarge
 
             MediaButton {
                 icon: "󰒮"
@@ -641,8 +641,8 @@ SystemComponents.TopbarPopup {
                                   : (mediaArea.containsMouse ? Theme.separator : "transparent")
         opacity: enabled ? 1 : 0.38
 
-        Behavior on color { ColorAnimation { duration: 120 } }
-        Behavior on opacity { NumberAnimation { duration: 120 } }
+        Behavior on color { ColorAnimation { duration: Theme.animationQuick } }
+        Behavior on opacity { NumberAnimation { duration: Theme.animationQuick } }
 
         Text {
             anchors.centerIn: parent
@@ -671,8 +671,8 @@ SystemComponents.TopbarPopup {
 
         Column {
             anchors.fill: parent
-            anchors.margins: 8
-            spacing: 4
+            anchors.margins: Theme.spacing
+            spacing: Theme.spacingMicro
 
             ConnectivityRow {
                 width: parent.width
@@ -721,18 +721,18 @@ SystemComponents.TopbarPopup {
         color: active ? Qt.rgba(Theme.accent.r, Theme.accent.g, Theme.accent.b, 0.22)
                       : (rowMouse.containsMouse ? Theme.separator : "transparent")
 
-        Behavior on color { ColorAnimation { duration: 130 } }
+        Behavior on color { ColorAnimation { duration: Theme.animationSubtle } }
 
         Row {
             anchors.fill: parent
-            anchors.leftMargin: 7
-            anchors.rightMargin: 7
-            spacing: 8
+            anchors.leftMargin: Theme.spacingInset
+            anchors.rightMargin: Theme.spacingInset
+            spacing: Theme.spacing
 
             Rectangle {
                 width: 28
                 height: 28
-                radius: 14
+                radius: Theme.cornerRadiusLarge
                 anchors.verticalCenter: parent.verticalCenter
                 color: rowRoot.active ? Theme.iconActive : Theme.surface
 
@@ -761,7 +761,7 @@ SystemComponents.TopbarPopup {
                     width: parent.width
                     text: rowRoot.subtitle
                     color: Theme.textSecondary
-                    opacity: 0.9
+                    opacity: Theme.opacityEmphasis
                     elide: Text.ElideRight
                     font { family: Theme.fontFamily; pixelSize: Theme.fontSizeMicro; weight: Font.Medium }
                 }
@@ -792,18 +792,18 @@ SystemComponents.TopbarPopup {
         border.width: 1
         border.color: active ? Qt.rgba(Theme.accent.r, Theme.accent.g, Theme.accent.b, 0.36) : Theme.border
 
-        Behavior on color { ColorAnimation { duration: 140 } }
-        Behavior on border.color { ColorAnimation { duration: 140 } }
+        Behavior on color { ColorAnimation { duration: Theme.animationHover } }
+        Behavior on border.color { ColorAnimation { duration: Theme.animationHover } }
 
         Row {
             anchors.fill: parent
-            anchors.margins: 10
-            spacing: 9
+            anchors.margins: Theme.spacingMedium
+            spacing: Theme.spacingControlGap
 
             Rectangle {
                 width: 30
                 height: 30
-                radius: 15
+                radius: height / 2
                 anchors.verticalCenter: parent.verticalCenter
                 color: tile.active ? Theme.iconActive : Theme.surface
 
@@ -832,7 +832,7 @@ SystemComponents.TopbarPopup {
                     width: parent.width
                     text: tile.subtitle
                     color: Theme.textSecondary
-                    opacity: 0.9
+                    opacity: Theme.opacityEmphasis
                     elide: Text.ElideRight
                     font { family: Theme.fontFamily; pixelSize: Theme.fontSizeCaption }
                 }
@@ -870,11 +870,11 @@ SystemComponents.TopbarPopup {
         Text {
             anchors.left: parent.left
             anchors.top: parent.top
-            anchors.leftMargin: 12
-            anchors.topMargin: 9
+            anchors.leftMargin: Theme.spacingLarge
+            anchors.topMargin: Theme.spacingControlGap
             text: sliderCard.title
             color: Theme.textActive
-            opacity: 0.86
+            opacity: Theme.opacitySubtle
             font { family: Theme.fontFamily; pixelSize: Theme.fontSizeSmall; weight: Font.DemiBold }
         }
 
@@ -882,8 +882,8 @@ SystemComponents.TopbarPopup {
             id: sliderLeftIcon
             anchors.left: parent.left
             anchors.bottom: parent.bottom
-            anchors.leftMargin: 12
-            anchors.bottomMargin: 12
+            anchors.leftMargin: Theme.spacingLarge
+            anchors.bottomMargin: Theme.spacingLarge
             text: sliderCard.leftIcon
             color: sliderCard.muted ? Theme.iconMuted : Theme.iconMain
             font { family: Theme.fontFamily; pixelSize: Theme.fontSizeIcon }
@@ -902,8 +902,8 @@ SystemComponents.TopbarPopup {
             anchors.left: sliderLeftIcon.right
             anchors.right: sliderRightIcon.left
             anchors.verticalCenter: sliderLeftIcon.verticalCenter
-            anchors.leftMargin: 12
-            anchors.rightMargin: 12
+            anchors.leftMargin: Theme.spacingLarge
+            anchors.rightMargin: Theme.spacingLarge
             height: 24
 
             Rectangle {
@@ -925,7 +925,7 @@ SystemComponents.TopbarPopup {
                     }
                     Behavior on width {
                         enabled: sliderCard.animateValue
-                        NumberAnimation { duration: 60; easing.type: Easing.OutCubic }
+                        NumberAnimation { duration: Theme.animationSlider; easing.type: Easing.OutCubic }
                     }
                 }
             }
@@ -938,10 +938,10 @@ SystemComponents.TopbarPopup {
                 radius: width / 2
                 color: Theme.iconActive
 
-                Behavior on width { NumberAnimation { duration: 100; easing.type: Easing.OutCubic } }
+                Behavior on width { NumberAnimation { duration: Theme.animationMicro; easing.type: Easing.OutCubic } }
                 Behavior on x {
                     enabled: !sliderMouse.pressed && sliderCard.animateValue
-                    NumberAnimation { duration: 60; easing.type: Easing.OutCubic }
+                    NumberAnimation { duration: Theme.animationSlider; easing.type: Easing.OutCubic }
                 }
 
                 Rectangle {
@@ -975,8 +975,8 @@ SystemComponents.TopbarPopup {
             id: sliderRightIcon
             anchors.right: parent.right
             anchors.bottom: parent.bottom
-            anchors.rightMargin: 12
-            anchors.bottomMargin: 12
+            anchors.rightMargin: Theme.spacingLarge
+            anchors.bottomMargin: Theme.spacingLarge
             text: sliderCard.rightIcon
             color: sliderCard.muted ? Theme.iconMuted : Theme.iconMain
             font { family: Theme.fontFamily; pixelSize: Theme.fontSizeIcon }

--- a/src/Quickshell/bar/ui/components/controlcenter/ReorderableStack.qml
+++ b/src/Quickshell/bar/ui/components/controlcenter/ReorderableStack.qml
@@ -1,11 +1,12 @@
 import QtQuick
+import "../../.."
 
 Item {
     id: root
 
     property var model: null
     property bool editMode: false
-    property real itemSpacing: 14
+    property real itemSpacing: Theme.spacingXLarge
     property var itemHeightProvider: function(key) { return 0 }
     property var itemLabelProvider: function(key) { return "" }
     property Component itemDelegate: null
@@ -15,12 +16,12 @@ Item {
     property int dragPreviewIndex: -1
     property real dragTop: 0
 
-    property real editOverlayRadius: 14
+    property real editOverlayRadius: Theme.cornerRadiusLarge
     property color editOverlayColor: Qt.rgba(0.10, 0.55, 1.0, 0.06)
     property color editOverlayBorderColor: Qt.rgba(0.35, 0.75, 1.0, 0.24)
     property color labelColor: Qt.rgba(1, 1, 1, 0.62)
-    property string labelFontFamily: "Inter"
-    property int labelPixelSize: 9
+    property string labelFontFamily: Theme.fontFamily
+    property int labelPixelSize: Theme.fontSizeMicro
 
     signal itemDropped()
 
@@ -157,14 +158,14 @@ Item {
             height: root.itemHeight(kind)
             z: isDragged ? 20 : (root.editMode ? 5 : 0)
             scale: isDragged ? 1.025 : 1
-            opacity: isDragged ? 0.94 : 1
+            opacity: isDragged ? Theme.opacityDragging : 1
 
             Behavior on y {
                 enabled: !stackDelegate.isDragged
-                NumberAnimation { duration: 150; easing.type: Easing.OutCubic }
+                NumberAnimation { duration: Theme.animationFast; easing.type: Easing.OutCubic }
             }
-            Behavior on scale { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
-            Behavior on opacity { NumberAnimation { duration: 120 } }
+            Behavior on scale { NumberAnimation { duration: Theme.animationQuick; easing.type: Easing.OutCubic } }
+            Behavior on opacity { NumberAnimation { duration: Theme.animationQuick } }
 
             Loader {
                 anchors.fill: parent
@@ -188,8 +189,8 @@ Item {
             Text {
                 anchors.left: parent.left
                 anchors.bottom: parent.bottom
-                anchors.leftMargin: 10
-                anchors.bottomMargin: 8
+                anchors.leftMargin: Theme.spacingMedium
+                anchors.bottomMargin: Theme.spacing
                 visible: root.editMode
                 text: root.itemLabel(kind)
                 color: root.labelColor

--- a/src/Quickshell/bar/ui/components/network/NetworkIndicator.qml
+++ b/src/Quickshell/bar/ui/components/network/NetworkIndicator.qml
@@ -17,6 +17,6 @@ SystemComponents.IndicatorButton {
             : "󰈀"
         color: !root.netConnected ? Theme.iconWarning : Theme.iconMain
         font { family: Theme.fontFamily; pixelSize: Theme.fontSizeIcon }
-        Behavior on color { ColorAnimation { duration: 150 } }
+        Behavior on color { ColorAnimation { duration: Theme.animationFast } }
     }
 }

--- a/src/Quickshell/bar/ui/components/network/NetworkPopup.qml
+++ b/src/Quickshell/bar/ui/components/network/NetworkPopup.qml
@@ -20,7 +20,7 @@ SystemComponents.TopbarPopup {
 
     Row {
         width: parent.width
-        spacing: 20
+        spacing: Theme.spacingXXLarge
 
         Repeater {
             model: [
@@ -28,7 +28,7 @@ SystemComponents.TopbarPopup {
                 { icon: "󰕒", label: "Upload",   value: root.uploadText   }
             ]
             delegate: Row {
-                spacing: 8
+                spacing: Theme.spacing
                 Text {
                     anchors.verticalCenter: parent.verticalCenter
                     text:  modelData.icon
@@ -40,7 +40,7 @@ SystemComponents.TopbarPopup {
                     Text {
                         text:    modelData.value
                         color:   Theme.textActive
-                        opacity: 0.85
+                        opacity: Theme.opacitySecondary
                         font { family: Theme.fontFamily; pixelSize: Theme.fontSizeBody; weight: Font.Medium }
                     }
                 }

--- a/src/Quickshell/bar/ui/components/system/Clock.qml
+++ b/src/Quickshell/bar/ui/components/system/Clock.qml
@@ -53,8 +53,8 @@ Item {
                 renderType: Text.NativeRendering
                 Behavior on text {
                     SequentialAnimation {
-                        NumberAnimation { target: _dateText; property: "opacity"; to: 0; duration: 120 }
-                        NumberAnimation { target: _dateText; property: "opacity"; to: 1; duration: 120 }
+                        NumberAnimation { target: _dateText; property: "opacity"; to: 0; duration: Theme.animationQuick }
+                        NumberAnimation { target: _dateText; property: "opacity"; to: 1; duration: Theme.animationQuick }
                     }
                 }
             }
@@ -86,8 +86,8 @@ Item {
                 renderType: Text.NativeRendering
                 Behavior on text {
                     SequentialAnimation {
-                        NumberAnimation { target: _clockText; property: "opacity"; to: 0; duration: 150; easing.type: Easing.InQuad }
-                        NumberAnimation { target: _clockText; property: "opacity"; to: 1; duration: 200; easing.type: Easing.OutQuad }
+                        NumberAnimation { target: _clockText; property: "opacity"; to: 0; duration: Theme.animationFast; easing.type: Easing.InQuad }
+                        NumberAnimation { target: _clockText; property: "opacity"; to: 1; duration: Theme.animationNormal; easing.type: Easing.OutQuad }
                     }
                 }
             }

--- a/src/Quickshell/bar/ui/components/system/IndicatorButton.qml
+++ b/src/Quickshell/bar/ui/components/system/IndicatorButton.qml
@@ -7,8 +7,8 @@ Item {
     property var popupRef: null
     property bool active: popupRef ? popupRef.shown : false
     property int fixedWidth: 0
-    property int horizontalPadding: 16
-    property int backgroundMargin: 3
+    property int horizontalPadding: Theme.spacingContainer
+    property int backgroundMargin: Theme.spacingTiny
     property int backgroundRadius: Theme.radiusMedium - 2
     property color activeColor: Qt.rgba(1, 1, 1, 0.15)
     property color pressedColor: Qt.rgba(1, 1, 1, 0.12)
@@ -52,7 +52,7 @@ Item {
              : control.hovered ? control.hoverColor
              : control.idleColor
 
-        Behavior on color { ColorAnimation { duration: 100 } }
+        Behavior on color { ColorAnimation { duration: Theme.animationMicro } }
     }
 
     HoverHandler {
@@ -62,7 +62,7 @@ Item {
     Row {
         id: contentRow
         anchors.centerIn: parent
-        spacing: 4
+        spacing: Theme.spacingMicro
     }
 
     MouseArea {

--- a/src/Quickshell/bar/ui/components/system/PopupHeader.qml
+++ b/src/Quickshell/bar/ui/components/system/PopupHeader.qml
@@ -24,7 +24,7 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
         text: control.title
         color: Theme.textActive
-        opacity: 0.85
+        opacity: Theme.opacitySecondary
         width: parent.width - trailingSlot.width - control.trailingGap
         elide: Text.ElideRight
         font {

--- a/src/Quickshell/bar/ui/components/system/Tray.qml
+++ b/src/Quickshell/bar/ui/components/system/Tray.qml
@@ -6,7 +6,7 @@ import "../../.."
 
 Row {
     id: root
-    spacing: 8
+    spacing: Theme.spacing
     height:  36
 
     function trayIconSource(icon) {
@@ -43,7 +43,7 @@ Row {
             width:  28; height: 28
             radius: Theme.radiusMedium
             color:  isHovered || isPressed ? (isPressed ? Qt.rgba(1, 1, 1, 0.2) : Theme.separator) : "transparent"
-            Behavior on color { ColorAnimation { duration: 150 } }
+            Behavior on color { ColorAnimation { duration: Theme.animationFast } }
 
             ToolTip.visible: isHovered && (modelData.tooltipTitle !== "" || modelData.title !== "")
             ToolTip.text:    modelData.tooltipTitle || modelData.title || ""

--- a/src/Quickshell/bar/ui/components/system/Workspaces.qml
+++ b/src/Quickshell/bar/ui/components/system/Workspaces.qml
@@ -2,7 +2,7 @@ import Quickshell.Hyprland
 import QtQuick
 import "../../.."
 Row {
-    spacing: 6
+    spacing: Theme.spacingSmall
     Repeater {
         // Filtra workspaces especiais (ex: scratchpad 'special:magic' que tem id < 0)
         model: Hyprland.workspaces.values.filter(ws => ws.id > 0)
@@ -14,8 +14,8 @@ Row {
             radius: Theme.workspaceDotSize / 2
             color: isActive ? Theme.workspaceActive : Theme.workspaceInactive
             anchors.verticalCenter: parent.verticalCenter
-            Behavior on width { NumberAnimation { duration: 200; easing.type: Easing.OutExpo } }
-            Behavior on color { ColorAnimation  { duration: 180 } }
+            Behavior on width { NumberAnimation { duration: Theme.animationNormal; easing.type: Easing.OutExpo } }
+            Behavior on color { ColorAnimation  { duration: Theme.animationNormal - 20 } }
             MouseArea {
                 anchors.fill: parent
                 anchors.topMargin:    -10

--- a/src/Quickshell/bar/ui/components/volume/VolumeIndicator.qml
+++ b/src/Quickshell/bar/ui/components/volume/VolumeIndicator.qml
@@ -26,6 +26,6 @@ SystemComponents.IndicatorButton {
             :                      "󰕾"
         color: root.volMuted ? Theme.iconMuted : Theme.iconMain
         font { family: Theme.fontFamily; pixelSize: Theme.fontSizeIcon }
-        Behavior on color { ColorAnimation { duration: 150 } }
+        Behavior on color { ColorAnimation { duration: Theme.animationFast } }
     }
 }

--- a/src/Quickshell/bar/ui/components/volume/VolumePopup.qml
+++ b/src/Quickshell/bar/ui/components/volume/VolumePopup.qml
@@ -81,7 +81,7 @@ SystemComponents.TopbarPopup {
         Rectangle {
             id: mutePill
             anchors.centerIn: parent
-            width: 28; height: 28; radius: 14
+            width: 28; height: 28; radius: Theme.cornerRadiusLarge
 
             color: root.masterMuted
                 ? Qt.rgba(1, 0.23, 0.19, 0.25)
@@ -92,15 +92,15 @@ SystemComponents.TopbarPopup {
                 ? Qt.rgba(1, 0.23, 0.19, 0.40)
                 : Qt.rgba(1, 1, 1, 0.08)
 
-            Behavior on color        { ColorAnimation { duration: 150 } }
-            Behavior on border.color { ColorAnimation { duration: 150 } }
+            Behavior on color        { ColorAnimation { duration: Theme.animationFast } }
+            Behavior on border.color { ColorAnimation { duration: Theme.animationFast } }
 
             Text {
                 anchors.centerIn: parent
                 text:  root.volIcon(root.masterVol, root.masterMuted)
                 color: root.masterMuted ? Theme.iconWarning : Theme.iconMain
                 font { family: Theme.fontFamily; pixelSize: Theme.fontSizeBody }
-                Behavior on color { ColorAnimation { duration: 150 } }
+                Behavior on color { ColorAnimation { duration: Theme.animationFast } }
             }
 
             MouseArea {
@@ -115,7 +115,7 @@ SystemComponents.TopbarPopup {
 
     Row {
         width:   parent.width
-        spacing: 10
+        spacing: Theme.spacingMedium
 
         Text {
             text:  "󰕿"
@@ -144,7 +144,7 @@ SystemComponents.TopbarPopup {
                         GradientStop { position: 0.0; color: root.masterMuted ? Qt.rgba(1,1,1,0.15) : Qt.rgba(1,1,1,0.45) }
                         GradientStop { position: 1.0; color: root.masterMuted ? Qt.rgba(1,1,1,0.20) : Qt.rgba(1,1,1,0.90) }
                     }
-                    Behavior on width { NumberAnimation { duration: 60; easing.type: Easing.OutCubic } }
+                    Behavior on width { NumberAnimation { duration: Theme.animationSlider; easing.type: Easing.OutCubic } }
                 }
             }
 
@@ -158,10 +158,10 @@ SystemComponents.TopbarPopup {
                 radius: width / 2
                 color:  "white"
 
-                Behavior on width { NumberAnimation { duration: 100; easing.type: Easing.OutCubic } }
+                Behavior on width { NumberAnimation { duration: Theme.animationMicro; easing.type: Easing.OutCubic } }
                 Behavior on x     {
                     enabled: !sliderMouse.pressed
-                    NumberAnimation { duration: 60; easing.type: Easing.OutCubic }
+                    NumberAnimation { duration: Theme.animationSlider; easing.type: Easing.OutCubic }
                 }
 
                 Rectangle {

--- a/src/Quickshell/desktop/DesktopIcons.qml
+++ b/src/Quickshell/desktop/DesktopIcons.qml
@@ -2,6 +2,9 @@ import Quickshell
 import Quickshell.Io
 import Quickshell.Wayland
 import QtQuick
+// TODO(design-system): desktop temporarily imports the bar module only for Theme tokens;
+// move Quickshell surfaces to a shared shell theme module before removing this dependency.
+import "../bar"
 import "AstreaFiles" as AstreaFiles
 
 Item {
@@ -22,6 +25,9 @@ Item {
     property bool stateLoaded: false
     property var gridPositions: ({})
     property int layoutVersion: 0
+    property string activeDragDesktop: ""
+    property int dragPreviewSlot: -1
+    property int dragSourceSlot: -1
     property string appLoadStatus: ""
     property string desktopSignature: ""
     readonly property string modulePath: localPath(Qt.resolvedUrl("."))
@@ -92,21 +98,25 @@ Item {
         return false
     }
 
-    function occupiedSlot(slot, exceptDesktop) {
+    function slotOwner(slot, exceptDesktop) {
         var items = orderedApps()
 
         for (var i = 0; i < items.length; i++) {
             var desktop = items[i].desktop
             var itemSlot = gridPositions[desktop] !== undefined ? gridPositions[desktop] : i
             if (desktop !== exceptDesktop && itemSlot === slot)
-                return true
+                return desktop
         }
 
         for (var key in gridPositions) {
             if (key !== exceptDesktop && gridPositions[key] === slot)
-                return true
+                return key
         }
-        return false
+        return ""
+    }
+
+    function occupiedSlot(slot, exceptDesktop) {
+        return slotOwner(slot, exceptDesktop) !== ""
     }
 
     function nearestFreeSlot(preferredSlot, exceptDesktop) {
@@ -127,13 +137,44 @@ Item {
     }
 
     function setDesktopSlot(desktop, slot) {
+        moveDesktopToSlot(desktop, slot, gridPositions[desktop] !== undefined ? gridPositions[desktop] : indexForDesktop(desktop))
+    }
+
+    function moveDesktopToSlot(desktop, slot, sourceSlot) {
+        if (!desktop)
+            return
+
+        var targetSlot = Math.max(0, Math.round(Number(slot) || 0))
+        var fromSlot = Math.max(0, Math.round(Number(sourceSlot) || 0))
+        var owner = slotOwner(targetSlot, desktop)
         var next = {}
-        for (var key in gridPositions)
-            next[key] = gridPositions[key]
-        next[desktop] = nearestFreeSlot(slot, desktop)
+        var items = orderedApps()
+
+        for (var i = 0; i < items.length; i++) {
+            var itemDesktop = items[i].desktop
+            if (itemDesktop)
+                next[itemDesktop] = gridPositions[itemDesktop] !== undefined ? gridPositions[itemDesktop] : i
+        }
+
+        for (var key in gridPositions) {
+            if (next[key] === undefined)
+                next[key] = gridPositions[key]
+        }
+
+        next[desktop] = targetSlot
+        if (owner !== "")
+            next[owner] = fromSlot
+
         gridPositions = next
+        normalizeGridPositions()
         layoutVersion += 1
         saveState()
+    }
+
+    function clearDragPreview() {
+        activeDragDesktop = ""
+        dragPreviewSlot = -1
+        dragSourceSlot = -1
     }
 
     function clearGridPositions() {
@@ -471,6 +512,14 @@ Item {
                 return col * rows + row
             }
 
+            function slotIndexForTileCenter(tile) {
+                return slotIndexFor(tile.x + tile.width / 2, tile.y + tile.height / 2)
+            }
+
+            function updateDragPreview(tile) {
+                root.dragPreviewSlot = slotIndexForTileCenter(tile)
+            }
+
             function clampTile(tile) {
                 tile.x = Math.max(0, Math.min(tile.x, contextHost.width - tile.width))
                 tile.y = Math.max(48, Math.min(tile.y, contextHost.height - tile.height))
@@ -504,6 +553,26 @@ Item {
                     id: iconLayer
                     anchors.fill: parent
 
+                    Rectangle {
+                        id: dropPreview
+                        readonly property point previewPosition: desktopWindow.defaultPosition(root.dragPreviewSlot)
+
+                        visible: root.activeDragDesktop !== "" && root.dragPreviewSlot >= 0
+                        x: previewPosition.x + Math.round((root.cellWidth - width) / 2)
+                        y: previewPosition.y + 3
+                        width: root.highlightWidth
+                        height: root.highlightHeight
+                        radius: Theme.cornerRadius
+                        color: Qt.rgba(Theme.accent.r, Theme.accent.g, Theme.accent.b, 0.13)
+                        border.width: 1
+                        border.color: Qt.rgba(Theme.accent.r, Theme.accent.g, Theme.accent.b, 0.42)
+                        opacity: visible ? 1 : 0
+
+                        Behavior on x { NumberAnimation { duration: Theme.animationQuick; easing.type: Easing.OutCubic } }
+                        Behavior on y { NumberAnimation { duration: Theme.animationQuick; easing.type: Easing.OutCubic } }
+                        Behavior on opacity { NumberAnimation { duration: Theme.animationQuick } }
+                    }
+
                     Repeater {
                         id: iconRepeater
                         model: {
@@ -528,8 +597,11 @@ Item {
 
                             property bool dragging: false
                             property bool movedDuringDrag: false
+                            property bool suppressClick: false
                             property real pressTileX: 0
                             property real pressTileY: 0
+                            property real pressMouseX: 0
+                            property real pressMouseY: 0
                             readonly property bool selected: tile.appData && root.selectedDesktop === tile.appData.desktop
                             readonly property bool hovered: tileHover.hovered
 
@@ -551,12 +623,12 @@ Item {
 
                             Behavior on x {
                                 enabled: !tile.dragging
-                                NumberAnimation { duration: 120; easing.type: Easing.OutCubic }
+                                NumberAnimation { duration: Theme.animationQuick; easing.type: Easing.OutCubic }
                             }
 
                             Behavior on y {
                                 enabled: !tile.dragging
-                                NumberAnimation { duration: 120; easing.type: Easing.OutCubic }
+                                NumberAnimation { duration: Theme.animationQuick; easing.type: Easing.OutCubic }
                             }
 
                             Connections {
@@ -571,11 +643,11 @@ Item {
                                 height: root.highlightHeight
                                 x: Math.round((parent.width - width) / 2)
                                 y: 3
-                                radius: 8
+                                radius: Theme.cornerRadius
                                 color: tile.selected ? "#3a3a3c" : tile.hovered ? "#2e2e30" : "transparent"
 
                                 Behavior on color {
-                                    ColorAnimation { duration: 90 }
+                                    ColorAnimation { duration: Theme.animationInstant }
                                 }
                             }
 
@@ -595,12 +667,12 @@ Item {
                             Text {
                                 id: appLabel
                                 anchors.top: appIcon.bottom
-                                anchors.topMargin: 6
+                                anchors.topMargin: Theme.spacingSmall
                                 width: root.cellWidth + 20
                                 anchors.horizontalCenter: parent.horizontalCenter
                                 text: tile.appData ? tile.appData.name : ""
                                 color: "#f8f8f8"
-                                font.family: "Inter Variable"
+                                font.family: Theme.fontFamily
                                 font.pixelSize: iconPreset === "large" ? 13 : iconPreset === "small" ? 12 : 12
                                 font.weight: Font.Normal
                                 font.hintingPreference: Font.PreferVerticalHinting
@@ -625,37 +697,66 @@ Item {
                                 z: 1
                                 hoverEnabled: true
                                 acceptedButtons: Qt.LeftButton | Qt.RightButton
-                                cursorShape: Qt.PointingHandCursor
+                                cursorShape: tile.dragging ? Qt.ClosedHandCursor : Qt.PointingHandCursor
                                 propagateComposedEvents: false
-                                drag.target: tile
-                                drag.axis: Drag.XAndYAxis
-                                drag.minimumX: 0
-                                drag.minimumY: 48
-                                drag.maximumX: Math.max(0, contextHost.width - tile.width)
-                                drag.maximumY: Math.max(48, contextHost.height - tile.height)
-                                drag.threshold: 6
+
+                                function beginDrag() {
+                                    if (tile.dragging || !tile.appData)
+                                        return
+
+                                    tile.dragging = true
+                                    tile.movedDuringDrag = true
+                                    tile.suppressClick = true
+                                    root.activeDragDesktop = tile.appData.desktop
+                                    root.dragSourceSlot = tile.effectiveSlot
+                                    root.dragPreviewSlot = tile.effectiveSlot
+                                    desktopWindow.closeContext()
+                                }
+
+                                function updateTileFromMouse(mouse) {
+                                    const pt = pointer.mapToItem(contextHost, mouse.x, mouse.y)
+                                    tile.x = tile.pressTileX + pt.x - tile.pressMouseX
+                                    tile.y = tile.pressTileY + pt.y - tile.pressMouseY
+                                    desktopWindow.clampTile(tile)
+                                    desktopWindow.updateDragPreview(tile)
+                                }
 
                                 onPressed: function(mouse) {
                                     if (tile.appData)
                                         root.selectedDesktop = tile.appData.desktop
                                     if (mouse.button === Qt.LeftButton) {
+                                        const pt = pointer.mapToItem(contextHost, mouse.x, mouse.y)
                                         tile.pressTileX = tile.x
                                         tile.pressTileY = tile.y
+                                        tile.pressMouseX = pt.x
+                                        tile.pressMouseY = pt.y
                                         tile.movedDuringDrag = false
-                                        tile.dragging = true
+                                        tile.suppressClick = false
                                     }
                                 }
 
                                 onPositionChanged: function(mouse) {
-                                    if (pressedButtons & Qt.LeftButton) {
-                                        var moved = Math.abs(tile.x - tile.pressTileX) + Math.abs(tile.y - tile.pressTileY)
-                                        if (moved > 2)
-                                            tile.movedDuringDrag = true
-                                    }
+                                    if (!(pressedButtons & Qt.LeftButton))
+                                        return
+
+                                    const pt = pointer.mapToItem(contextHost, mouse.x, mouse.y)
+                                    const dx = pt.x - tile.pressMouseX
+                                    const dy = pt.y - tile.pressMouseY
+                                    const threshold = 8
+
+                                    if (!tile.dragging && Math.sqrt(dx * dx + dy * dy) >= threshold)
+                                        beginDrag()
+
+                                    if (tile.dragging)
+                                        updateTileFromMouse(mouse)
                                 }
 
                                 onClicked: function(mouse) {
                                     mouse.accepted = true
+                                    if (tile.suppressClick) {
+                                        tile.suppressClick = false
+                                        return
+                                    }
                                     if (!tile.appData)
                                         return
                                     root.selectedDesktop = tile.appData.desktop
@@ -678,22 +779,22 @@ Item {
 
                                 onReleased: function(mouse) {
                                     if (mouse.button === Qt.LeftButton) {
-                                        var moved = tile.movedDuringDrag
-                                            || Math.abs(tile.x - tile.pressTileX) + Math.abs(tile.y - tile.pressTileY) > 2
-                                        desktopWindow.clampTile(tile)
-                                        if (moved) {
-                                            var dropPoint = pointer.mapToItem(contextHost, mouse.x, mouse.y)
-                                            if (tile.appData)
-                                                root.setDesktopSlot(tile.appData.desktop, desktopWindow.slotIndexFor(dropPoint.x, dropPoint.y))
+                                        if (tile.dragging && tile.appData) {
+                                            updateTileFromMouse(mouse)
+                                            root.moveDesktopToSlot(tile.appData.desktop, root.dragPreviewSlot, root.dragSourceSlot)
                                         }
                                         tile.dragging = false
                                         tile.movedDuringDrag = false
+                                        root.clearDragPreview()
+                                        desktopWindow.clampTile(tile)
                                     }
                                 }
 
                                 onCanceled: {
                                     tile.dragging = false
                                     tile.movedDuringDrag = false
+                                    tile.suppressClick = false
+                                    root.clearDragPreview()
                                     desktopWindow.clampTile(tile)
                                 }
                             }


### PR DESCRIPTION
### Motivation

- Consolidate UI design tokens (spacing, radii, motion, opacity, typography) to enable safer, incremental standardization of Settings and shell surfaces. 
- Replace ad-hoc literals and duplicated values across Core and Quickshell with semantic Theme tokens to improve consistency and make a future global token module possible. 
- Provide a low-risk migration path that keeps existing entry points while enabling shared component cleanup. 
- Improve desktop icon drag-and-drop UX and slot management to support previews and more predictable moves.

### Description

- Added `docs/design-system-standardization-audit.md` documenting scope, findings, token recommendations, and a safe migration path. 
- Extended `src/Core/components/theme/Theme.qml` with layout, spacing, motion, and opacity tokens (e.g. `spacing*`, `cornerRadius*`, `animation*`, `opacity*`, `cardRadius`, `controlRadius`) and switched many Core form components to consume these tokens. 
- Added/expanded matching tokens in `src/Quickshell/bar/Theme.qml` and updated numerous Quickshell UI components to use those tokens for spacing, radii, animation durations, opacity, and font families instead of hardcoded literals. 
- Refactored many form and shell components (`FormCard`, `IconListRow`, `ScrollPage`, `SectionHeader`, `SelectButton`, `SettingRow`, `ToggleSwitch`, etc.) to use `Components.Theme.*` tokens for consistent layout and animated behaviors. 
- Enhanced `src/Quickshell/desktop/DesktopIcons.qml` with improved slot ownership helpers (`slotOwner`, `occupiedSlot`), explicit `moveDesktopToSlot`, drag preview visuals, suppression of accidental clicks during drag, and smoother drag/preview animation timings using Theme tokens.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc96bc8f988326ba22e749bdad33b4)