### PR TITLE
Harden Astrea runtime backends and shared helpers

### DIFF
--- a/config/hypr/scripts/toggle_all_float.sh
+++ b/config/hypr/scripts/toggle_all_float.sh
@@ -1,18 +1,27 @@
 #!/bin/bash
+set -euo pipefail
 
-STATE_FILE="/tmp/hypr_float_state"
+if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    STATE_DIR="${XDG_RUNTIME_DIR}/Astrea/hypr"
+else
+    STATE_DIR="${HOME}/.local/state/Astrea/hypr"
+fi
+STATE_FILE="${STATE_DIR}/float_state"
+mkdir -p "${STATE_DIR}"
 
 if [[ -f "$STATE_FILE" ]]; then
-    # Reverter: só as janelas que a gente flotou
     while IFS= read -r addr; do
+        [[ -n "$addr" ]] || continue
         hyprctl dispatch togglefloating "address:$addr"
     done < "$STATE_FILE"
-    rm "$STATE_FILE"
+    rm -f "$STATE_FILE"
 else
-    # Flotar todas as janelas tiled de todos os workspaces
-    hyprctl clients -j | jq -r '.[] | select(.floating == false) | .address' > "$STATE_FILE"
-    
+    tmp="$(mktemp "${STATE_FILE}.XXXXXX")"
+    hyprctl clients -j | jq -r '.[] | select(.floating == false) | .address' > "$tmp"
+    mv -f "$tmp" "$STATE_FILE"
+
     while IFS= read -r addr; do
+        [[ -n "$addr" ]] || continue
         hyprctl dispatch togglefloating "address:$addr"
     done < "$STATE_FILE"
 fi

--- a/src/Core/bridge/apps/manager.py
+++ b/src/Core/bridge/apps/manager.py
@@ -1,109 +1,18 @@
 #!/usr/bin/env python3
 
 import argparse
-import configparser
 import json
-import os
 import shutil
 import stat
 import subprocess
 import sys
 from pathlib import Path
 
+BRIDGE_DIR = Path(__file__).resolve().parents[1]
+if str(BRIDGE_DIR) not in sys.path:
+    sys.path.insert(0, str(BRIDGE_DIR))
 
-def resolve_icon_path(icon_name: str) -> str:
-    if not icon_name:
-        return ""
-
-    candidate = Path(icon_name).expanduser()
-    if candidate.is_file():
-        return str(candidate)
-
-    theme = "hicolor"
-    theme_variants = [theme]
-
-    try:
-        import subprocess
-        gtk = subprocess.check_output(
-            ["gsettings", "get", "org.gnome.desktop.interface", "icon-theme"],
-            stderr=subprocess.DEVNULL,
-            text=True,
-        ).strip().strip("'")
-        if gtk:
-            theme = gtk
-            theme_variants = [theme]
-    except Exception:
-        pass
-
-    for suffix in ["-dark", "-light", "-Dark", "-Light"]:
-        if theme.endswith(suffix):
-            theme_variants.append(theme[:-len(suffix)])
-
-    base_dirs = [Path.home() / ".local/share/icons", Path("/usr/share/icons")]
-    sizes = ["256x256", "128x128", "96x96", "64x64", "48x48", "32x32", "24x24", "22x22", "16x16", "scalable"]
-    exts = [".svg", ".png", ".xpm"]
-    subpaths = [
-        "{size}/apps/{name}{ext}",
-        "apps/{size}/{name}{ext}",
-        "apps/scalable/{name}{ext}",
-    ]
-
-    for base in base_dirs:
-        for theme_name in theme_variants:
-            theme_dir = base / theme_name
-            if not theme_dir.is_dir():
-                continue
-            for size in sizes:
-                for subpath in subpaths:
-                    for ext in exts:
-                        candidate = theme_dir / subpath.format(size=size, name=icon_name, ext=ext)
-                        if candidate.is_file():
-                            return str(candidate)
-
-    for ext in exts:
-        pixmap = Path("/usr/share/pixmaps") / f"{icon_name}{ext}"
-        if pixmap.is_file():
-            return str(pixmap)
-
-    return ""
-
-
-def application_dirs() -> list[Path]:
-    home = Path.home()
-    data_home = Path(os.environ.get("XDG_DATA_HOME", home / ".local/share"))
-    dirs = [data_home / "applications"]
-
-    for entry in os.environ.get("XDG_DATA_DIRS", "/usr/local/share:/usr/share").split(":"):
-        if entry:
-            dirs.append(Path(entry) / "applications")
-
-    deduped: list[Path] = []
-    seen: set[str] = set()
-    for path in dirs:
-        key = str(path)
-        if key not in seen:
-            seen.add(key)
-            deduped.append(path)
-    return deduped
-
-
-def xdg_desktop_dir() -> Path:
-    config_path = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "user-dirs.dirs"
-    fallback = Path.home() / "Desktop"
-
-    try:
-        for line in config_path.read_text(encoding="utf-8", errors="ignore").splitlines():
-            line = line.strip()
-            if not line.startswith("XDG_DESKTOP_DIR="):
-                continue
-            value = line.split("=", 1)[1].strip().strip('"')
-            value = value.replace("$HOME", str(Path.home()))
-            return Path(os.path.expandvars(value)).expanduser()
-    except Exception:
-        pass
-
-    return fallback
-
+from astrea_shared import application_dirs, parse_desktop_file, xdg_desktop_dir
 
 def is_protected_app(app: dict) -> bool:
     app_id = (app.get("id") or "").casefold()
@@ -116,49 +25,6 @@ def is_protected_app(app: dict) -> bool:
     )
 
 
-def parse_desktop_file(path: Path, source: str) -> dict | None:
-    parser = configparser.ConfigParser(interpolation=None, strict=False)
-    parser.optionxform = str
-
-    try:
-        parser.read(path, encoding="utf-8")
-    except Exception:
-        return None
-
-    if "Desktop Entry" not in parser:
-        return None
-
-    entry = parser["Desktop Entry"]
-    if entry.get("Type", "Application") != "Application":
-        return None
-
-    if entry.get("NoDisplay", "").lower() == "true":
-        return None
-    if entry.get("Hidden", "").lower() == "true":
-        return None
-
-    name = entry.get("Name", "").strip()
-    if not name:
-        return None
-
-    exec_line = entry.get("Exec", "").strip()
-    icon_name = entry.get("Icon", "").strip()
-    comment = entry.get("Comment", "").strip()
-    categories = [part for part in entry.get("Categories", "").split(";") if part]
-
-    return {
-        "id": path.name,
-        "name": name,
-        "comment": comment,
-        "exec": exec_line,
-        "icon": icon_name,
-        "icon_path": resolve_icon_path(icon_name),
-        "categories": categories,
-        "desktop_file": str(path),
-        "source": source,
-        "protected": path.name == "astrea-settings.desktop",
-    }
-
 
 def list_apps() -> dict:
     apps_by_id: dict[str, dict] = {}
@@ -169,7 +35,7 @@ def list_apps() -> dict:
 
         source = "user" if str(apps_dir).startswith(str(Path.home())) else "system"
         for desktop_file in sorted(apps_dir.glob("*.desktop")):
-            parsed = parse_desktop_file(desktop_file, source)
+            parsed = parse_desktop_file(desktop_file, source=source)
             if not parsed:
                 continue
             apps_by_id[parsed["id"]] = parsed
@@ -195,7 +61,7 @@ def find_app(identifier: str) -> dict:
 
     path = Path(identifier).expanduser()
     if path.is_file():
-        parsed = parse_desktop_file(path, "user" if str(path).startswith(str(Path.home())) else "system")
+        parsed = parse_desktop_file(path, source="user" if str(path).startswith(str(Path.home())) else "system")
         if parsed:
             return parsed
 

--- a/src/Core/bridge/astrea_shared.py
+++ b/src/Core/bridge/astrea_shared.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Shared runtime helpers for Astrea backend scripts."""
+
+from __future__ import annotations
+
+import configparser
+import json
+import locale
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+FALLBACK_ICON = "application-x-executable"
+
+
+def atomic_write_text(path: Path, text: str, *, encoding: str = "utf-8") -> None:
+    """Write text via a same-directory temporary file and atomic replace."""
+    path = Path(path).expanduser()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    tmp = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding=encoding) as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def atomic_write_json(path: Path, payload: Any, *, indent: int | None = 2, sort_keys: bool = False) -> None:
+    text = json.dumps(payload, ensure_ascii=False, indent=indent, sort_keys=sort_keys)
+    atomic_write_text(path, text + "\n")
+
+
+def read_json(path: Path, default: Any) -> Any:
+    try:
+        with Path(path).expanduser().open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        return data
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return default
+
+
+def xdg_data_home() -> Path:
+    return Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local/share")).expanduser()
+
+
+def xdg_config_home() -> Path:
+    return Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")).expanduser()
+
+
+def xdg_state_home() -> Path:
+    return Path(os.environ.get("XDG_STATE_HOME", Path.home() / ".local/state")).expanduser()
+
+
+def xdg_runtime_dir(app_name: str = "Astrea") -> Path:
+    runtime = os.environ.get("XDG_RUNTIME_DIR")
+    if runtime:
+        return Path(runtime).expanduser() / app_name
+    return xdg_state_home() / app_name / "runtime"
+
+
+def xdg_desktop_dir() -> Path:
+    config_path = xdg_config_home() / "user-dirs.dirs"
+    fallback = Path.home() / "Desktop"
+    try:
+        for line in config_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+            line = line.strip()
+            if not line.startswith("XDG_DESKTOP_DIR="):
+                continue
+            value = line.split("=", 1)[1].strip().strip('"')
+            value = value.replace("$HOME", str(Path.home()))
+            return Path(os.path.expandvars(value)).expanduser()
+    except OSError:
+        pass
+    return fallback
+
+
+def application_dirs() -> list[Path]:
+    dirs = [xdg_data_home() / "applications"]
+    for entry in os.environ.get("XDG_DATA_DIRS", "/usr/local/share:/usr/share").split(":"):
+        if entry:
+            dirs.append(Path(entry).expanduser() / "applications")
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for path in dirs:
+        key = str(path)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(path)
+    return deduped
+
+
+def _current_icon_theme() -> str:
+    try:
+        theme = subprocess.check_output(
+            ["gsettings", "get", "org.gnome.desktop.interface", "icon-theme"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2,
+        ).strip().strip("'")
+        return theme or "hicolor"
+    except Exception:
+        return "hicolor"
+
+
+def resolve_icon_path(icon_name: str) -> str:
+    if not icon_name or "://" in icon_name:
+        return ""
+    candidate = Path(icon_name).expanduser()
+    if candidate.is_file():
+        return str(candidate)
+
+    theme = _current_icon_theme()
+    theme_variants = [theme]
+    for suffix in ["-dark", "-light", "-Dark", "-Light"]:
+        if theme.endswith(suffix):
+            theme_variants.append(theme[: -len(suffix)])
+
+    base_dirs = [Path.home() / ".local/share/icons", Path("/usr/share/icons")]
+    sizes = ["256x256", "128x128", "96x96", "64x64", "48x48", "32x32", "24x24", "22x22", "16x16", "scalable"]
+    exts = [".svg", ".png", ".xpm"]
+    subpaths = ["{size}/apps/{name}{ext}", "apps/{size}/{name}{ext}", "apps/scalable/{name}{ext}"]
+
+    for base in base_dirs:
+        for theme_name in theme_variants:
+            theme_dir = base / theme_name
+            if not theme_dir.is_dir():
+                continue
+            for size in sizes:
+                for subpath in subpaths:
+                    for ext in exts:
+                        path = theme_dir / subpath.format(size=size, name=icon_name, ext=ext)
+                        if path.is_file():
+                            return str(path)
+
+    for ext in exts:
+        pixmap = Path("/usr/share/pixmaps") / f"{icon_name}{ext}"
+        if pixmap.is_file():
+            return str(pixmap)
+    return ""
+
+
+def localized_keys(base: str) -> list[str]:
+    lang, _ = locale.getlocale()
+    keys: list[str] = []
+    if lang:
+        normalized = lang.replace("-", "_")
+        keys.append(f"{base}[{normalized}]")
+        if "_" in normalized:
+            keys.append(f"{base}[{normalized.split('_', 1)[0]}]")
+    keys.append(base)
+    return keys
+
+
+def localized_value(entry: configparser.SectionProxy, base: str) -> str:
+    for key in localized_keys(base):
+        value = entry.get(key, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def icon_has_localhost_reference(icon: str) -> bool:
+    if "/" not in icon:
+        return False
+    path = Path(icon).expanduser()
+    try:
+        return path.suffix.lower() == ".svg" and path.is_file() and "localhost:" in path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+
+
+def safe_desktop_icon(icon: str, *, fallback: str = FALLBACK_ICON) -> str:
+    icon = (icon or "").strip()
+    if not icon or "://" in icon or icon_has_localhost_reference(icon):
+        return fallback
+    return icon
+
+
+def parse_desktop_file(path: Path, *, source: str = "", skip_terminal: bool = False, require_exec: bool = False) -> dict[str, Any] | None:
+    parser = configparser.ConfigParser(interpolation=None, strict=False)
+    parser.optionxform = str
+    try:
+        parser.read(path, encoding="utf-8")
+    except Exception:
+        return None
+    if "Desktop Entry" not in parser:
+        return None
+
+    entry = parser["Desktop Entry"]
+    if entry.get("Type", "Application") != "Application":
+        return None
+    if entry.get("NoDisplay", "false").lower() == "true" or entry.get("Hidden", "false").lower() == "true":
+        return None
+    if skip_terminal and entry.get("Terminal", "false").lower() == "true":
+        return None
+
+    name = localized_value(entry, "Name")
+    exec_line = entry.get("Exec", "").strip()
+    if not name or (require_exec and not exec_line):
+        return None
+
+    icon_name = safe_desktop_icon(entry.get("Icon", ""), fallback=FALLBACK_ICON)
+    categories = [part for part in entry.get("Categories", "").split(";") if part]
+    return {
+        "id": path.name,
+        "name": name,
+        "generic": localized_value(entry, "GenericName"),
+        "comment": localized_value(entry, "Comment"),
+        "exec": exec_line,
+        "icon": icon_name,
+        "icon_path": resolve_icon_path(icon_name),
+        "categories": categories,
+        "desktop_file": str(path),
+        "desktop": str(path),
+        "source": source,
+        "protected": path.name == "astrea-settings.desktop",
+    }

--- a/src/Core/bridge/system/audio.py
+++ b/src/Core/bridge/system/audio.py
@@ -11,8 +11,13 @@ import sys
 import json
 import subprocess
 import re
-import os
 from pathlib import Path
+
+BRIDGE_DIR = Path(__file__).resolve().parents[1]
+if str(BRIDGE_DIR) not in sys.path:
+    sys.path.insert(0, str(BRIDGE_DIR))
+
+from astrea_shared import atomic_write_json, atomic_write_text, read_json, resolve_icon_path
 
 # ── WirePlumber config path ───────────────────────────────────────────────────
 WP_CONF = Path.home() / ".config/wireplumber/wireplumber.conf.d/50-astrea-audio.conf"
@@ -29,27 +34,46 @@ def eprint(msg):
     print(msg, file=sys.stderr)
 
 def get_aliases():
-    if not ALIASES_CONF.exists():
+    data = read_json(ALIASES_CONF, {})
+    if not isinstance(data, dict):
         return {}
-    try:
-        c = ALIASES_CONF.read_text()
-        return json.loads(c) if c else {}
-    except Exception:
-        return {}
+    aliases = {}
+    for name, alias in data.items():
+        try:
+            name_s = validate_wp_string(str(name), field="device name")
+            alias_s = validate_wp_string(str(alias), field="alias")
+        except ValueError:
+            continue
+        aliases[name_s] = alias_s
+    return aliases
+
+
+def validate_wp_string(value: str, *, field: str) -> str:
+    value = (value or "").strip()
+    if not value:
+        raise ValueError(f"{field} vazio")
+    if len(value) > 256:
+        raise ValueError(f"{field} muito longo")
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in value):
+        raise ValueError(f"{field} contem caracteres de controle")
+    return value
+
+
+def wp_quote(value: str) -> str:
+    return json.dumps(validate_wp_string(value, field="WirePlumber string"), ensure_ascii=False)
+
 
 def save_alias(name, custom_name):
     aliases = get_aliases()
-    if custom_name.strip() == "":
-        if name in aliases:
-            del aliases[name]
+    device_name = validate_wp_string(str(name), field="device name")
+    alias = str(custom_name or "").strip()
+    if alias == "":
+        aliases.pop(device_name, None)
     else:
-        aliases[name] = custom_name.strip()
-    ALIASES_CONF.parent.mkdir(parents=True, exist_ok=True)
-    try:
-        ALIASES_CONF.write_text(json.dumps(aliases, ensure_ascii=False))
-    except Exception:
-        pass
+        aliases[device_name] = validate_wp_string(alias, field="alias")
+    atomic_write_json(ALIASES_CONF, aliases, indent=None, sort_keys=True)
     update_wp_aliases_file()
+
 
 def update_wp_aliases_file():
     aliases = get_aliases()
@@ -59,73 +83,28 @@ def update_wp_aliases_file():
             conf.unlink()
         return
 
-    out = []
-    for k, v in aliases.items():
-        out.append(f"""  {{
-    matches = [ {{ node.name = "{k}" }} ]
-    actions = {{ update-props = {{ node.description = "{v}" }} }}
-  }}""")
-    rules_str = ",\n".join(out)
+    rules = []
+    for name, alias in sorted(aliases.items()):
+        try:
+            quoted_name = wp_quote(name)
+            quoted_alias = wp_quote(alias)
+        except ValueError as exc:
+            eprint(f"[aliases] ignorando alias invalido: {exc}")
+            continue
+        rules.append(
+            "  {\n"
+            f"    matches = [ {{ node.name = {quoted_name} }} ]\n"
+            f"    actions = {{ update-props = {{ node.description = {quoted_alias} }} }}\n"
+            "  }"
+        )
+    if not rules:
+        if conf.exists():
+            conf.unlink()
+        return
+    rules_str = ",\n".join(rules)
     content = f"monitor.alsa.rules = [\n{rules_str}\n]\n\n"
     content += f"monitor.bluez.rules = [\n{rules_str}\n]\n\n"
-    conf.parent.mkdir(parents=True, exist_ok=True)
-    conf.write_text(content)
-
-# ── Resolve path do ícone no tema ─────────────────────────────────────────────
-def resolve_icon_path(icon_name: str) -> str:
-    if not icon_name:
-        return ""
-
-    theme = "hicolor"
-    try:
-        gtk = subprocess.check_output(
-            ["gsettings", "get", "org.gnome.desktop.interface", "icon-theme"],
-            stderr=subprocess.DEVNULL, text=True
-        ).strip().strip("'")
-        if gtk:
-            theme = gtk
-    except Exception:
-        pass
-
-    # tenta o tema exato e variantes sem sufixo (-dark, -light)
-    theme_variants = [theme]
-    for suffix in ["-dark", "-light", "-Dark", "-Light"]:
-        if theme.endswith(suffix):
-            theme_variants.append(theme[:-len(suffix)])
-
-    base_dirs = [os.path.expanduser("~/.local/share/icons"), "/usr/share/icons"]
-    sizes = ["48x48", "64x64", "128x128", "256x256", "scalable", "32x32", "22x22", "16x16"]
-    exts  = [".svg", ".png", ".xpm"]
-
-    # estruturas de pasta que diferentes temas usam
-    subpaths = [
-        "{size}/apps/{name}{ext}",   # hicolor padrão
-        "apps/{size}/{name}{ext}",   # Numix
-        "apps/scalable/{name}{ext}", # WhiteSur (ignora size)
-    ]
-
-    for base in base_dirs:
-        for t in theme_variants:
-            theme_dir = os.path.join(base, t)
-            if not os.path.isdir(theme_dir):
-                continue
-            for size in sizes:
-                for subpath in subpaths:
-                    for ext in exts:
-                        path = os.path.join(
-                            theme_dir,
-                            subpath.format(size=size, name=icon_name, ext=ext)
-                        )
-                        if os.path.isfile(path):
-                            return path
-
-    # fallback: pixmaps
-    for ext in exts:
-        path = f"/usr/share/pixmaps/{icon_name}{ext}"
-        if os.path.isfile(path):
-            return path
-
-    return ""
+    atomic_write_text(conf, content)
 
 # ── Lê dispositivos via pactl ─────────────────────────────────────────────────
 def get_default_sink() -> str:
@@ -299,14 +278,20 @@ def apply_config(cfg: dict):
         print("wp_restart_required: true")
 
 def _write_wp_conf(cfg: dict):
-    WP_CONF.parent.mkdir(parents=True, exist_ok=True)
-    WP_CONF.write_text(
+    sample_rate = int(cfg.get("sample_rate", 48000))
+    buffer_size = int(cfg.get("buffer_size", 1024))
+    if sample_rate < 8000 or sample_rate > 384000:
+        raise ValueError("sample_rate fora do intervalo seguro")
+    if buffer_size < 32 or buffer_size > 8192:
+        raise ValueError("buffer_size fora do intervalo seguro")
+    atomic_write_text(
+        WP_CONF,
         "# Astrea Audio Settings — gerado automaticamente\n"
         "wireplumber.settings = {\n"
-        f"  default.clock.rate          = {cfg['sample_rate']}\n"
-        f"  default.clock.quantum       = {cfg['buffer_size']}\n"
-        f"  default.clock.min-quantum   = 32\n"
-        f"  default.clock.max-quantum   = 8192\n"
+        f"  default.clock.rate          = {sample_rate}\n"
+        f"  default.clock.quantum       = {buffer_size}\n"
+        "  default.clock.min-quantum   = 32\n"
+        "  default.clock.max-quantum   = 8192\n"
         "}\n"
     )
 

--- a/src/Core/bridge/wallpaper/blur_lockscreen.py
+++ b/src/Core/bridge/wallpaper/blur_lockscreen.py
@@ -4,7 +4,9 @@ blur_lockscreen.py — Astrea lockscreen blur generator
 Gera o blur no mesmo diretório do arquivo original e cria um symlink (aponta para ele)
 """
 import argparse
+import os
 import sys
+import tempfile
 from pathlib import Path
 from PIL import Image, ImageFilter
 
@@ -23,9 +25,19 @@ def generate_blur(input_path: Path, output_path: Path | None = None) -> Path:
     blurred_file = real_output_dir / "blurred.jpg"
 
     if not blurred_file.exists() or real_input.stat().st_mtime > blurred_file.stat().st_mtime:
-        with Image.open(real_input) as img:
-            blurred = img.convert("RGB").filter(ImageFilter.GaussianBlur(radius=RADIUS))
-            blurred.save(blurred_file, "JPEG", quality=92, optimize=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{blurred_file.name}.", suffix=".tmp", dir=str(real_output_dir))
+        os.close(fd)
+        tmp = Path(tmp_name)
+        try:
+            with Image.open(real_input) as img:
+                blurred = img.convert("RGB").filter(ImageFilter.GaussianBlur(radius=RADIUS))
+                blurred.save(tmp, "JPEG", quality=92, optimize=True)
+            os.replace(tmp, blurred_file)
+        finally:
+            try:
+                tmp.unlink()
+            except FileNotFoundError:
+                pass
 
     if output_path:
         if output_path.exists() or output_path.is_symlink():

--- a/src/Core/bridge/wallpaper/img_cache.py
+++ b/src/Core/bridge/wallpaper/img_cache.py
@@ -3,7 +3,9 @@
 Astrea Orchestrator — O motor de miniaturas do Vitor.
 """
 import argparse
+import os
 import sys
+import tempfile
 from pathlib import Path
 from PIL import Image
 
@@ -37,9 +39,19 @@ def process_image(src: Path, dest: Path) -> bool:
             print(f"  [ERR] não encontrado: {src}", file=sys.stderr)
             return False
         dest.parent.mkdir(parents=True, exist_ok=True)
-        with Image.open(src) as img:
-            thumb = _crop_center(img.convert("RGB"), THUMB_SIZE)
-            thumb.save(dest, "JPEG", quality=THUMB_QUALITY, optimize=True)
+        fd, tmp_name = tempfile.mkstemp(prefix=f".{dest.name}.", suffix=".tmp", dir=str(dest.parent))
+        os.close(fd)
+        tmp = Path(tmp_name)
+        try:
+            with Image.open(src) as img:
+                thumb = _crop_center(img.convert("RGB"), THUMB_SIZE)
+                thumb.save(tmp, "JPEG", quality=THUMB_QUALITY, optimize=True)
+            os.replace(tmp, dest)
+        finally:
+            try:
+                tmp.unlink()
+            except FileNotFoundError:
+                pass
         return True
     except Exception as e:
         print(f"  [ERR] {src.name}: {e}", file=sys.stderr)

--- a/src/Core/bridge/wallpaper/wallpaper_manager.py
+++ b/src/Core/bridge/wallpaper/wallpaper_manager.py
@@ -8,6 +8,12 @@ import subprocess
 import sys
 from pathlib import Path
 
+BRIDGE_DIR = Path(__file__).resolve().parents[1]
+if str(BRIDGE_DIR) not in sys.path:
+    sys.path.insert(0, str(BRIDGE_DIR))
+
+from astrea_shared import atomic_write_text
+
 PROJECT_DIR = Path.home() / ".local/share/Astrea"
 FEATURES_DIR = PROJECT_DIR / "Features/Paper"
 USER_DATA_DIR = PROJECT_DIR / "Data/user"
@@ -47,8 +53,7 @@ def read_text(path: Path, default: str = "") -> str:
 
 
 def write_text(path: Path, value: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(f"{value}\n", encoding="utf-8")
+    atomic_write_text(path, f"{value}\n")
 
 
 def relink(target: Path, source: Path) -> None:

--- a/src/Quickshell/desktop/app_index.py
+++ b/src/Quickshell/desktop/app_index.py
@@ -2,106 +2,18 @@
 
 from __future__ import annotations
 
-import json
-import locale
 import argparse
-import os
-from configparser import ConfigParser
+import json
+import sys
 from pathlib import Path
 
+BRIDGE_DIR = Path(__file__).resolve().parents[2] / "Core" / "bridge"
+if str(BRIDGE_DIR) not in sys.path:
+    sys.path.insert(0, str(BRIDGE_DIR))
+
+from astrea_shared import FALLBACK_ICON, atomic_write_json, atomic_write_text, parse_desktop_file, xdg_desktop_dir
 
 MAX_APPS = 64
-FALLBACK_ICON = "application-x-executable"
-
-
-def xdg_desktop_dir() -> Path:
-    config_path = Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "user-dirs.dirs"
-    fallback = Path.home() / "Desktop"
-
-    try:
-        for line in config_path.read_text(encoding="utf-8", errors="ignore").splitlines():
-            line = line.strip()
-            if not line.startswith("XDG_DESKTOP_DIR="):
-                continue
-
-            value = line.split("=", 1)[1].strip().strip('"')
-            value = value.replace("$HOME", str(Path.home()))
-            return Path(os.path.expandvars(value)).expanduser()
-    except Exception:
-        pass
-
-    return fallback
-def localized_keys(base: str) -> list[str]:
-    lang, _ = locale.getlocale()
-    keys: list[str] = []
-    if lang:
-        normalized = lang.replace("-", "_")
-        keys.append(f"{base}[{normalized}]")
-        if "_" in normalized:
-            keys.append(f"{base}[{normalized.split('_', 1)[0]}]")
-    keys.append(base)
-    return keys
-
-
-def localized_value(entry, base: str) -> str:
-    for key in localized_keys(base):
-        value = entry.get(key, "").strip()
-        if value:
-            return value
-    return ""
-
-
-def icon_has_localhost_reference(icon: str) -> bool:
-    if "/" not in icon:
-        return False
-
-    path = Path(icon)
-    try:
-        return path.suffix.lower() == ".svg" and path.is_file() and "localhost:" in path.read_text(encoding="utf-8", errors="ignore")
-    except Exception:
-        return False
-
-
-def parse_entry(path: Path) -> dict[str, str] | None:
-    parser = ConfigParser(interpolation=None, strict=False)
-    parser.optionxform = str
-
-    try:
-        parser.read(path, encoding="utf-8")
-    except Exception:
-        return None
-
-    if "Desktop Entry" not in parser:
-        return None
-
-    entry = parser["Desktop Entry"]
-    if entry.get("Type", "Application") != "Application":
-        return None
-    if entry.get("NoDisplay", "false").lower() == "true":
-        return None
-    if entry.get("Hidden", "false").lower() == "true":
-        return None
-    if entry.get("Terminal", "false").lower() == "true":
-        return None
-
-    name = localized_value(entry, "Name")
-    icon = entry.get("Icon", "").strip()
-    exec_line = entry.get("Exec", "").strip()
-    if not name or not exec_line:
-        return None
-    if "://" in icon:
-        icon = FALLBACK_ICON
-    if icon_has_localhost_reference(icon):
-        icon = FALLBACK_ICON
-    if not icon:
-        icon = FALLBACK_ICON
-
-    return {
-        "name": name,
-        "generic": localized_value(entry, "GenericName"),
-        "icon": icon,
-        "desktop": str(path),
-    }
 
 
 def collect_apps() -> list[dict[str, str]]:
@@ -113,16 +25,21 @@ def collect_apps() -> list[dict[str, str]]:
         return items
 
     for path in sorted(desktop_dir.glob("*.desktop")):
-        item = parse_entry(path)
-        if not item:
+        parsed = parse_desktop_file(path, source="desktop", skip_terminal=True, require_exec=True)
+        if not parsed:
             continue
 
-        key = Path(item["desktop"]).name
+        key = Path(parsed["desktop_file"]).name
         if key in seen:
             continue
 
         seen.add(key)
-        items.append(item)
+        items.append({
+            "name": str(parsed.get("name") or ""),
+            "generic": str(parsed.get("generic") or ""),
+            "icon": str(parsed.get("icon") or FALLBACK_ICON),
+            "desktop": str(parsed.get("desktop_file") or path),
+        })
 
     items.sort(key=lambda item: item["name"].casefold())
     return items
@@ -130,12 +47,11 @@ def collect_apps() -> list[dict[str, str]]:
 
 def write_js(items: list[dict[str, str]], output_path: Path) -> None:
     payload = json.dumps(items, ensure_ascii=False, indent=2)
-    output_path.write_text(f"var APPS = {payload};\n", encoding="utf-8")
+    atomic_write_text(output_path, f"var APPS = {payload};\n")
 
 
 def write_json(items: list[dict[str, str]], output_path: Path) -> None:
-    payload = json.dumps(items, ensure_ascii=False, indent=2)
-    output_path.write_text(payload + "\n", encoding="utf-8")
+    atomic_write_json(output_path, items, indent=2)
 
 
 def parse_args() -> argparse.Namespace:

--- a/src/Quickshell/island/scripts/spotify-sink.sh
+++ b/src/Quickshell/island/scripts/spotify-sink.sh
@@ -4,6 +4,43 @@ set -u
 CAVA_CONF="$(dirname "$0")/../config/cava.conf"
 MONITOR_SOURCE=""
 
+write_cava_conf() {
+    local source_name="$1"
+    mkdir -p "$(dirname "${CAVA_CONF}")"
+    local tmp
+    tmp="$(mktemp "${CAVA_CONF}.XXXXXX")"
+    cat > "${tmp}" <<EOF
+[general]
+bars = 6
+framerate = 60
+sensitivity = 100
+[input]
+method = pulse
+source = ${source_name}
+[output]
+method = raw
+raw_target = /dev/stdout
+data_format = ascii
+ascii_max_range = 100
+EOF
+    mv -f "${tmp}" "${CAVA_CONF}"
+}
+
+require_commands() {
+    local missing=()
+    local cmd
+    for cmd in pactl pw-dump jq awk grep mktemp; do
+        command -v "${cmd}" >/dev/null 2>&1 || missing+=("${cmd}")
+    done
+    if [ "${#missing[@]}" -gt 0 ]; then
+        write_cava_conf "__astrea_missing_dependency__.monitor"
+        printf 'missing:%s\n' "${missing[*]}"
+        exit 0
+    fi
+}
+
+require_commands
+
 source_exists() {
     local source_name="$1"
     [ -n "$source_name" ] || return 1
@@ -81,37 +118,16 @@ for i in {1..15}; do
 done
 
 if [ -z "$MONITOR_SOURCE" ]; then
-cat > "$CAVA_CONF" << EOF
-[general]
-bars = 6
-framerate = 60
-sensitivity = 100
-[input]
-method = pulse
-source = __astrea_no_music_app__.monitor
-[output]
-method = raw
-raw_target = /dev/stdout
-data_format = ascii
-ascii_max_range = 100
-EOF
+    write_cava_conf "__astrea_no_music_app__.monitor"
     echo "no-music:"
     exit 0
 fi
 
-cat > "$CAVA_CONF" << EOF
-[general]
-bars = 6
-framerate = 60
-sensitivity = 100
-[input]
-method = pulse
-source = $MONITOR_SOURCE
-[output]
-method = raw
-raw_target = /dev/stdout
-data_format = ascii
-ascii_max_range = 100
-EOF
+if ! [[ "${MONITOR_SOURCE}" =~ ^[A-Za-z0-9_.:-]+$ ]]; then
+    write_cava_conf "__astrea_invalid_source__.monitor"
+    echo "invalid-source:"
+    exit 0
+fi
 
+write_cava_conf "${MONITOR_SOURCE}"
 echo "ok:$MONITOR_SOURCE"

--- a/src/System/scripts/bluetooth_manager.py
+++ b/src/System/scripts/bluetooth_manager.py
@@ -13,6 +13,12 @@ import time
 import traceback
 from pathlib import Path
 
+BRIDGE_DIR = Path(__file__).resolve().parents[2] / "Core" / "bridge"
+if str(BRIDGE_DIR) not in sys.path:
+    sys.path.insert(0, str(BRIDGE_DIR))
+
+from astrea_shared import atomic_write_json, read_json
+
 # ─── Paths ────────────────────────────────────────────────────────────────────
 
 STATE_DIR   = Path.home() / ".local" / "state" / "Astrea" / "bluetooth"
@@ -73,21 +79,13 @@ def _ensure_state_dir() -> None:
 
 
 def _read_json(path: Path, default: dict) -> dict:
-    if not path.exists():
-        return dict(default)
-    try:
-        data = json.loads(path.read_text())
-        return data if isinstance(data, dict) else dict(default)
-    except Exception:
-        return dict(default)
+    data = read_json(path, dict(default))
+    return data if isinstance(data, dict) else dict(default)
 
 
 def _write_json(path: Path, data: dict) -> None:
     _ensure_state_dir()
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(f".{path.name}.tmp")
-    tmp.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n")
-    tmp.replace(path)
+    atomic_write_json(path, data, indent=2, sort_keys=True)
 
 
 def _unlink(path: Path) -> None:

--- a/src/System/services/astrea_statusd.py
+++ b/src/System/services/astrea_statusd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import json
-import os
 import signal
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -14,6 +14,7 @@ BLUETOOTH_HELPER = ASTREA_ROOT / "System/scripts/bluetooth_manager.py"
 AUDIO_PATH = STATE_DIR / "audio.json"
 NETWORK_PATH = STATE_DIR / "network.json"
 BLUETOOTH_PATH = STATE_DIR / "bluetooth.json"
+HEALTH_PATH = STATE_DIR / "health.json"
 
 REFRESH_AUDIO_SEC = 10
 REFRESH_NETWORK_SEC = 30
@@ -24,7 +25,18 @@ refresh_requested = False
 running = True
 
 
+def dependency_payload(name: str, *, kind: str = "dependency_missing") -> dict:
+    return {"ok": False, "degraded": True, "error": kind, "message": f"Missing dependency: {name}"}
+
+
+def command_available(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
 def run_cmd(args, timeout=6):
+    if not args or not command_available(str(args[0])):
+        name = str(args[0]) if args else ""
+        return subprocess.CompletedProcess(args, 127, "", f"Missing dependency: {name}")
     try:
         return subprocess.run(args, text=True, capture_output=True, timeout=timeout, check=False)
     except Exception as exc:
@@ -45,6 +57,10 @@ def write_json_if_changed(path, payload):
 
 
 def audio_status():
+    if not command_available("wpctl"):
+        payload = dependency_payload("wpctl")
+        payload.update({"level": 0, "muted": False})
+        return payload
     proc = run_cmd(["wpctl", "get-volume", "@DEFAULT_AUDIO_SINK@"], timeout=3)
     muted = "[MUTED]" in proc.stdout
     level = 0
@@ -54,14 +70,21 @@ def audio_status():
             break
         except ValueError:
             pass
-    return {
+    payload = {
         "ok": proc.returncode == 0,
         "level": max(0, min(150, level)),
         "muted": muted,
     }
+    if proc.returncode != 0:
+        payload.update({"degraded": True, "error": proc.stderr.strip() or "wpctl_failed"})
+    return payload
 
 
 def network_status():
+    if not command_available("ip"):
+        payload = dependency_payload("ip")
+        payload.update({"connected": False, "type": "none", "ssid": "", "download": "0 B/s", "upload": "0 B/s"})
+        return payload
     route = run_cmd(["ip", "route", "get", "1.1.1.1"], timeout=3).stdout.split()
     iface = ""
     for index, token in enumerate(route):
@@ -74,11 +97,12 @@ def network_status():
     if (Path("/sys/class/net") / iface / "wireless").exists():
         net_type = "wifi"
         ssid = ""
-        wifi = run_cmd(["nmcli", "-t", "-f", "active,ssid", "dev", "wifi"], timeout=4).stdout
-        for line in wifi.splitlines():
-            if line.startswith("yes:"):
-                ssid = line.split(":", 1)[1]
-                break
+        if command_available("nmcli"):
+            wifi = run_cmd(["nmcli", "-t", "-f", "active,ssid", "dev", "wifi"], timeout=4).stdout
+            for line in wifi.splitlines():
+                if line.startswith("yes:"):
+                    ssid = line.split(":", 1)[1]
+                    break
     else:
         net_type = "wired"
         ssid = "Ethernet"
@@ -93,6 +117,14 @@ def network_status():
 
 
 def bluetooth_status():
+    if not command_available("python3"):
+        payload = dependency_payload("python3")
+        payload.update({"powered": False, "connected_name": "", "paired_devices": []})
+        return payload
+    if not BLUETOOTH_HELPER.exists():
+        payload = dependency_payload(str(BLUETOOTH_HELPER), kind="helper_missing")
+        payload.update({"powered": False, "connected_name": "", "paired_devices": []})
+        return payload
     proc = run_cmd(["python3", str(BLUETOOTH_HELPER), "status"], timeout=8)
     try:
         payload = json.loads(proc.stdout or "{}")
@@ -106,7 +138,24 @@ def bluetooth_status():
 
 
 def bluetooth_autoconnect():
-    run_cmd(["python3", str(BLUETOOTH_HELPER), "autoconnect"], timeout=20)
+    if command_available("python3") and BLUETOOTH_HELPER.exists():
+        run_cmd(["python3", str(BLUETOOTH_HELPER), "autoconnect"], timeout=20)
+
+
+def health_payload() -> dict:
+    deps = {
+        "wpctl": command_available("wpctl"),
+        "ip": command_available("ip"),
+        "nmcli": command_available("nmcli"),
+        "python3": command_available("python3"),
+        "bluetooth_helper": BLUETOOTH_HELPER.exists(),
+    }
+    return {
+        "ok": all(deps.values()),
+        "degraded": not all(deps.values()),
+        "dependencies": deps,
+        "updated_at": int(time.time()),
+    }
 
 
 def handle_refresh(_signum, _frame):
@@ -135,6 +184,7 @@ def main():
             refresh_requested = False
 
         if now >= next_audio:
+            write_json_if_changed(HEALTH_PATH, health_payload())
             write_json_if_changed(AUDIO_PATH, audio_status())
             next_audio = now + REFRESH_AUDIO_SEC
 

--- a/src/System/services/display_apply.sh
+++ b/src/System/services/display_apply.sh
@@ -6,32 +6,57 @@ apply_mode="${1:-full}"
 conf_path="${HOME}/.local/share/Astrea/System/config/display/monitor-settings.conf"
 [ -f "${conf_path}" ] || exit 0
 
-source "${conf_path}"
+read_conf_value() {
+    local key="$1"
+    local fallback="${2:-}"
+    awk -F= -v key="${key}" -v fallback="${fallback}" '
+        /^[[:space:]]*#/ { next }
+        $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
+            value = substr($0, index($0, "=") + 1)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+            if (value ~ /^[A-Za-z0-9_.:@+,% -]+$/) { print value; found=1; exit }
+        }
+        END { if (!found) print fallback }
+    ' "${conf_path}"
+}
 
-monitor=${monitor:-}
-resolution=${resolution:-preferred}
-refreshrate=${refreshrate:-60}
-scale=${scale:-1}
-bitdepth=${bitdepth:-8}
-vrr=${vrr:-0}
-saturation=${saturation:-950}
-night_shift=${night_shift:-0}
-night_shift_strength=${night_shift_strength:-35}
-night_shift_schedule=${night_shift_schedule:-0}
-night_shift_start=${night_shift_start:-20:00}
-night_shift_end=${night_shift_end:-07:00}
-monitor_id=${monitor_id:-0}
+monitor="$(read_conf_value monitor "")"
+resolution="$(read_conf_value resolution preferred)"
+refreshrate="$(read_conf_value refreshrate 60)"
+scale="$(read_conf_value scale 1)"
+bitdepth="$(read_conf_value bitdepth 8)"
+vrr="$(read_conf_value vrr 0)"
+saturation="$(read_conf_value saturation 950)"
+night_shift="$(read_conf_value night_shift 0)"
+night_shift_strength="$(read_conf_value night_shift_strength 35)"
+night_shift_schedule="$(read_conf_value night_shift_schedule 0)"
+night_shift_start="$(read_conf_value night_shift_start 20:00)"
+night_shift_end="$(read_conf_value night_shift_end 07:00)"
+monitor_id="$(read_conf_value monitor_id 0)"
 if [ -z "${monitor}" ]; then
     monitor="$(hyprctl monitors -j 2>/dev/null | python3 -c 'import json,sys; data=json.load(sys.stdin); print(data[0].get("name","")) if data else None' 2>/dev/null || true)"
 fi
 [ -n "${monitor}" ] || exit 0
+
+for numeric_name in refreshrate bitdepth vrr saturation night_shift night_shift_strength night_shift_schedule monitor_id; do
+    numeric_value="${!numeric_name}"
+    if ! [[ "${numeric_value}" =~ ^[0-9]+$ ]]; then
+        printf -v "${numeric_name}" %s 0
+    fi
+done
+if ! [[ "${scale}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    scale=1
+fi
 
 saturation=$(( saturation < 0 ? 0 : (saturation > 1023 ? 1023 : saturation) ))
 monitor_rule="monitor=${monitor},${resolution}@${refreshrate},0x0,${scale},bitdepth,${bitdepth},vrr,${vrr}"
 night_shift_color="${HOME}/.local/share/Astrea/System/services/display_night_shift_color.sh"
 
 mkdir -p "${HOME}/.config/hypr/core"
-printf '%s\n' "${monitor_rule}" > "${HOME}/.config/hypr/core/monitors.conf"
+monitors_conf="${HOME}/.config/hypr/core/monitors.conf"
+tmp_monitors="$(mktemp "${monitors_conf}.XXXXXX")"
+printf '%s\n' "${monitor_rule}" > "${tmp_monitors}"
+mv -f "${tmp_monitors}" "${monitors_conf}"
 
 if [ "${apply_mode}" = "full" ]; then
     # Apply immediately for the current session, then reload so the persisted

--- a/src/System/services/display_night_shift_schedule.sh
+++ b/src/System/services/display_night_shift_schedule.sh
@@ -11,9 +11,26 @@ state_dir="${HOME}/.local/state/Astrea/display"
 state_path="${state_dir}/night-shift-state"
 lock_path="${state_dir}/night-shift.lock"
 
+read_conf_value() {
+    local key="$1"
+    local fallback="${2:-}"
+    awk -F= -v key="${key}" -v fallback="${fallback}" '
+        /^[[:space:]]*#/ { next }
+        $1 ~ "^[[:space:]]*" key "[[:space:]]*$" {
+            value = substr($0, index($0, "=") + 1)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+            if (value ~ /^[A-Za-z0-9_.:@+,% -]+$/) { print value; found=1; exit }
+        }
+        END { if (!found) print fallback }
+    ' "${conf_path}"
+}
+
 write_units() {
     mkdir -p "${unit_dir}"
-    cat > "${service_path}" <<EOF
+    local tmp_service tmp_timer
+    tmp_service="$(mktemp "${service_path}.XXXXXX")"
+    tmp_timer="$(mktemp "${timer_path}.XXXXXX")"
+    cat > "${tmp_service}" <<EOF
 [Unit]
 Description=Apply Astrea Night Shift schedule
 Documentation=file://${HOME}/.local/share/Astrea/System/services/display_night_shift_schedule.sh
@@ -26,7 +43,7 @@ TimeoutStartSec=8s
 Nice=5
 EOF
 
-    cat > "${timer_path}" <<EOF
+    cat > "${tmp_timer}" <<EOF
 [Unit]
 Description=Check Astrea Night Shift schedule
 
@@ -40,6 +57,8 @@ Persistent=true
 [Install]
 WantedBy=timers.target
 EOF
+    mv -f "${tmp_service}" "${service_path}"
+    mv -f "${tmp_timer}" "${timer_path}"
 }
 
 disable_units() {
@@ -116,13 +135,11 @@ apply_schedule() {
     flock -n 9 || exit 0
 
     [ -f "${conf_path}" ] || exit 0
-    # shellcheck source=/dev/null
-    source "${conf_path}"
 
-    night_shift_schedule=${night_shift_schedule:-0}
-    night_shift_strength=${night_shift_strength:-35}
-    night_shift_start=${night_shift_start:-20:00}
-    night_shift_end=${night_shift_end:-07:00}
+    night_shift_schedule="$(read_conf_value night_shift_schedule 0)"
+    night_shift_strength="$(read_conf_value night_shift_strength 35)"
+    night_shift_start="$(read_conf_value night_shift_start 20:00)"
+    night_shift_end="$(read_conf_value night_shift_end 07:00)"
 
     if ! [[ "${night_shift_strength}" =~ ^[0-9]+$ ]]; then
         night_shift_strength=35


### PR DESCRIPTION
### Motivation
- Reduce duplicated desktop parsing and icon lookup logic and centralize common runtime helpers. 
- Make runtime writes and generated config/thumbnails atomic to avoid races and partial files that break the UI. 
- Harden backends (audio, display, status, Bluetooth, wallpaper, hypr/spotify helpers) against malformed input, missing dependencies, and unsafe shell `source` usage. 
- Move ephemeral state out of `/tmp` to XDG locations so per-session state is deterministic and safer.

### Description
- Added `src/Core/bridge/astrea_shared.py` with atomic text/JSON writers (`atomic_write_text`, `atomic_write_json`), safe `read_json`, XDG path helpers, localized desktop parsing, icon resolution, and sanitizers used by multiple backends. 
- Replaced duplicated desktop parsing by refactoring `src/Core/bridge/apps/manager.py` and `src/Quickshell/desktop/app_index.py` to use `parse_desktop_file` and the shared icon resolver and to write generated `apps.js`/`apps.json` atomically. 
- Hardened audio handling in `src/Core/bridge/system/audio.py` by validating/escaping alias strings, using `read_json`/`atomic_write_json` for aliases, generating WirePlumber config via `atomic_write_text`, and reusing the shared icon resolution. 
- Made wallpaper thumbnail and blur generation atomic (`src/Core/bridge/wallpaper/img_cache.py`, `src/Core/bridge/wallpaper/blur_lockscreen.py`) and switched wallpaper state writes to `atomic_write_text` in `wallpaper_manager.py`. 
- Improved `astrea_statusd.py` to detect missing commands, emit clear degraded dependency payloads, add an optional `health` JSON payload, and keep the daemon running while publishing health + per-service JSON. 
- Removed unsafe `source` of display config and implemented keyed parsing in `src/System/services/display_apply.sh` and `display_night_shift_schedule.sh`, and made monitor/unit files writes atomic. 
- Hardened `spotify-sink.sh` to check required commands, validate monitor source names, and write `cava.conf` atomically. 
- Replaced `/tmp` Hypr float state usage with `XDG_RUNTIME_DIR` (or `~/.local/state/Astrea` fallback) and perform atomic/temp-file replacements in `config/hypr/scripts/toggle_all_float.sh`. 
- Refactored Bluetooth helper I/O to use the shared `read_json`/`atomic_write_json` helpers in `src/System/scripts/bluetooth_manager.py`.

### Testing
- Compiled Python modules with `python3 -m py_compile` for modified files and the new `astrea_shared.py` with no syntax errors. 
- Shell syntax checks via `bash -n` on `src/System/services/display_apply.sh`, `src/System/services/display_night_shift_schedule.sh`, `src/Quickshell/island/scripts/spotify-sink.sh`, and `config/hypr/scripts/toggle_all_float.sh`, all passed. 
- Verified JSON output shape for desktop lists by running `python3 src/Core/bridge/apps/manager.py list` and `python3 src/Quickshell/desktop/app_index.py --json` and formatting with `python3 -m json.tool` with no errors. 
- Performed smoke checks that atomic/temp-file writes succeed for generated config and state during local runs (thumbnail, blur, WirePlumber and CAVA writes) and observed expected behavior during tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd6eed87c8326869f90970482b99f)