### PR TITLE
Optimize Quickshell runtime state sharing

### DIFF
--- a/src/Quickshell/bar/Bar.qml
+++ b/src/Quickshell/bar/Bar.qml
@@ -1,10 +1,7 @@
 import Quickshell
 import Quickshell.Wayland
-import Quickshell.Io
 import QtQuick
 import "ui"
-import "modules/network"
-import "modules/bluetooth"
 import "ui/components/astrea"
 import "ui/components/bluetooth"
 import "ui/components/controlcenter"
@@ -22,32 +19,22 @@ PanelWindow {
     WlrLayershell.layer:         WlrLayer.Top
     WlrLayershell.exclusiveZone: 45
 
-    property bool   netConnected:  false
-    property string netType:       "none"
-    property string netSsid:       ""
-    property string netDownload:   "0 B/s"
-    property string netUpload:     "0 B/s"
-    property bool   btOn:          false
-    property string btDevicesJson: "[]"
-    property string btScannedJson: "[]"
-    property bool   btScanning:    false
-    property int    volLevel:      50
-    property bool   volMuted:      false
     property QtObject sharedMusicState: null
-    readonly property string audioStatusPath: (Quickshell.env("XDG_STATE_HOME") || (Quickshell.env("HOME") + "/.local/state")) + "/Astrea/status/audio.json"
+    property QtObject sharedNetworkState: null
+    property QtObject sharedBluetoothState: null
+    property QtObject sharedAudioState: null
 
-    function refreshVolume() {
-        audioStatusFile.reload()
-    }
-
-    function applyAudioStatus(text) {
-        try {
-            var payload = JSON.parse(text || "{}")
-            bar.volLevel = payload.level !== undefined ? payload.level : bar.volLevel
-            bar.volMuted = payload.muted === true
-        } catch (error) {
-        }
-    }
+    readonly property bool   netConnected:  sharedNetworkState ? sharedNetworkState.connected : false
+    readonly property string netType:       sharedNetworkState ? sharedNetworkState.type : "none"
+    readonly property string netSsid:       sharedNetworkState ? sharedNetworkState.ssid : ""
+    readonly property string netDownload:   sharedNetworkState ? sharedNetworkState.download : "0 B/s"
+    readonly property string netUpload:     sharedNetworkState ? sharedNetworkState.upload : "0 B/s"
+    readonly property bool   btOn:          sharedBluetoothState ? sharedBluetoothState.powered : false
+    readonly property string btDevicesJson: sharedBluetoothState ? sharedBluetoothState.devicesJson : "[]"
+    readonly property string btScannedJson: sharedBluetoothState ? sharedBluetoothState.scannedJson : "[]"
+    readonly property bool   btScanning:    sharedBluetoothState ? sharedBluetoothState.scanning : false
+    readonly property int    volLevel:      sharedAudioState ? sharedAudioState.level : 50
+    readonly property bool   volMuted:      sharedAudioState ? sharedAudioState.muted : false
 
     BarContent {
         anchors {
@@ -76,10 +63,8 @@ PanelWindow {
         onVolPopupRequested: anchorX => bar.toggleVolPopup(anchorX)
         onCcPopupRequested: anchorX => bar.toggleCcPopup(anchorX)
         onVolChangeRequested: function(v) {
-            bar.volLevel       = v
-            volSetProc.command = ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", v + "%"]
-            volSetProc.running = false
-            volSetProc.running = true
+            if (bar.sharedAudioState)
+                bar.sharedAudioState.setVolume(v)
         }
     }
 
@@ -126,58 +111,13 @@ PanelWindow {
     Item { id: volPopupButtonProbe; x: Math.max(0, bar.width - 118); y: 0; width: 36; height: 36; visible: false }
     Item { id: ccPopupButtonProbe; x: Math.max(0, bar.width - 82); y: 0; width: 36; height: 36; visible: false }
 
-    Process {
-        id:      volSetProc
-        command: []
-        running: false
-        onExited: {
-            statusRefreshProc.running = false
-            statusRefreshProc.running = true
-        }
-    }
-
-    Process {
-        id: statusRefreshProc
-        command: ["systemctl", "--user", "kill", "-s", "USR1", "astrea-status.service"]
-        running: false
-        onExited: bar.refreshVolume()
-    }
-
-    FileView {
-        id: audioStatusFile
-        path: bar.audioStatusPath
-        preload: true
-        blockLoading: true
-        watchChanges: true
-        printErrors: false
-        onFileChanged: reload()
-        onLoaded: bar.applyAudioStatus(text())
-    }
-
-    NetworkProcess {
-        id: netData
-        onConnectedChanged: bar.netConnected = netData.connected
-        onSsidChanged:      bar.netSsid      = netData.ssid
-        onTypeChanged:      bar.netType      = netData.type
-        onDownloadChanged:  bar.netDownload  = netData.download
-        onUploadChanged:    bar.netUpload    = netData.upload
-    }
-
-    BluetoothProcess {
-        id: btData
-        onPoweredChanged:     bar.btOn          = btData.powered
-        onDevicesJsonChanged: bar.btDevicesJson  = btData.devicesJson
-        onScannedJsonChanged: bar.btScannedJson  = btData.scannedJson
-        onScanningChanged:    bar.btScanning     = btData.scanning
-    }
-
     Loader {
         id: volPopupLoader
         active: false
         sourceComponent: VolumePopup {
             masterVol:   bar.volLevel
             masterMuted: bar.volMuted
-            onVolumeChangeHandled: (v) => bar.volLevel = v
+            onVolumeChangeHandled: (v) => { if (bar.sharedAudioState) bar.sharedAudioState.level = v }
         }
     }
 
@@ -200,7 +140,7 @@ PanelWindow {
             devicesJson: bar.btDevicesJson
             scannedJson: bar.btScannedJson
             scanning:    bar.btScanning
-            btProcess:   btData
+            btProcess:   bar.sharedBluetoothState
         }
     }
 
@@ -212,15 +152,15 @@ PanelWindow {
             netConnected: bar.netConnected
             netType: bar.netType
             ssid: bar.netSsid
-            netProcess: netData
+            netProcess: bar.sharedNetworkState
             btOn: bar.btOn
             btDevicesJson: bar.btDevicesJson
-            btProcess: btData
+            btProcess: bar.sharedBluetoothState
             masterVol: bar.volLevel
             masterMuted: bar.volMuted
             musicState: bar.sharedMusicState
-            onVolumeChangeHandled: (v) => bar.volLevel = v
-            onMuteChangeHandled: (muted) => bar.volMuted = muted
+            onVolumeChangeHandled: (v) => { if (bar.sharedAudioState) bar.sharedAudioState.level = v }
+            onMuteChangeHandled: (muted) => { if (bar.sharedAudioState) bar.sharedAudioState.muted = muted }
         }
     }
 

--- a/src/Quickshell/bar/modules/audio/AudioProcess.qml
+++ b/src/Quickshell/bar/modules/audio/AudioProcess.qml
@@ -1,0 +1,54 @@
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+QtObject {
+    id: root
+
+    readonly property string statusPath: (Quickshell.env("XDG_STATE_HOME") || (Quickshell.env("HOME") + "/.local/state")) + "/Astrea/status/audio.json"
+    property int level: 50
+    property bool muted: false
+
+    function refresh() {
+        statusRefreshProc.running = false
+        statusRefreshProc.running = true
+    }
+
+    function setVolume(value) {
+        root.level = value
+        volSetProc.command = ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", value + "%"]
+        volSetProc.running = false
+        volSetProc.running = true
+    }
+
+    function applyStatus(text) {
+        try {
+            var payload = JSON.parse(text || "{}")
+            root.level = payload.level !== undefined ? payload.level : root.level
+            root.muted = payload.muted === true
+        } catch (error) {
+        }
+    }
+
+    property var statusFile: FileView {
+        path: root.statusPath
+        preload: true
+        blockLoading: true
+        watchChanges: true
+        printErrors: false
+        onFileChanged: reload()
+        onLoaded: root.applyStatus(text())
+    }
+
+    property var volSetProc: Process {
+        command: []
+        running: false
+        onExited: root.refresh()
+    }
+
+    property var statusRefreshProc: Process {
+        command: ["systemctl", "--user", "kill", "-s", "USR1", "astrea-status.service"]
+        running: false
+        onExited: statusFile.reload()
+    }
+}

--- a/src/Quickshell/bar/modules/audio/AudioProcess.qml
+++ b/src/Quickshell/bar/modules/audio/AudioProcess.qml
@@ -14,9 +14,17 @@ QtObject {
         statusRefreshProc.running = true
     }
 
+    function clampLevel(value) {
+        var parsed = Math.round(Number(value))
+        if (!isFinite(parsed))
+            parsed = root.level
+        return Math.max(0, Math.min(150, parsed))
+    }
+
     function setVolume(value) {
-        root.level = value
-        volSetProc.command = ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", value + "%"]
+        var nextLevel = clampLevel(value)
+        root.level = nextLevel
+        volSetProc.command = ["wpctl", "set-volume", "@DEFAULT_AUDIO_SINK@", nextLevel + "%"]
         volSetProc.running = false
         volSetProc.running = true
     }
@@ -24,7 +32,7 @@ QtObject {
     function applyStatus(text) {
         try {
             var payload = JSON.parse(text || "{}")
-            root.level = payload.level !== undefined ? payload.level : root.level
+            root.level = payload.level !== undefined ? clampLevel(payload.level) : root.level
             root.muted = payload.muted === true
         } catch (error) {
         }

--- a/src/Quickshell/bar/modules/audio/qmldir
+++ b/src/Quickshell/bar/modules/audio/qmldir
@@ -1,0 +1,1 @@
+AudioProcess 1.0 AudioProcess.qml

--- a/src/Quickshell/bar/modules/bluetooth/BluetoothProcess.qml
+++ b/src/Quickshell/bar/modules/bluetooth/BluetoothProcess.qml
@@ -10,10 +10,11 @@ QtObject {
 
     property bool powered: false
     property string deviceName: ""
-    property string devicesJson: "[]"
-    property string scannedJson: "[]"
+    property var devices: []
+    property var scannedDevices: []
+    readonly property string devicesJson: JSON.stringify(devices)
+    readonly property string scannedJson: JSON.stringify(scannedDevices)
     property bool scanning: false
-    property var _scannedList: []
     property var _scanOwners: ({})
     property string _statusBuf: ""
     property string _powerBuf: ""
@@ -60,8 +61,7 @@ QtObject {
         if (root.scanning)
             return
         root.scanning = true
-        root._scannedList = []
-        root.scannedJson = "[]"
+        root.scannedDevices = []
         scanProc.running = false
         scanProc.running = true
     }
@@ -93,20 +93,17 @@ QtObject {
     }
 
     function _addScanned(mac, name) {
-        var paired = []
-        try { paired = JSON.parse(root.devicesJson) } catch (e) {}
-        for (var i = 0; i < paired.length; i++) {
-            if (paired[i].mac === mac)
+        for (var i = 0; i < root.devices.length; i++) {
+            if (root.devices[i].mac === mac)
                 return
         }
-        for (var j = 0; j < root._scannedList.length; j++) {
-            if (root._scannedList[j].mac === mac)
+        for (var j = 0; j < root.scannedDevices.length; j++) {
+            if (root.scannedDevices[j].mac === mac)
                 return
         }
-        var updated = root._scannedList.slice()
+        var updated = root.scannedDevices.slice()
         updated.push({ mac: mac, name: name, connected: false, trusted: false, auto_connect: true })
-        root._scannedList = updated
-        root.scannedJson = JSON.stringify(updated)
+        root.scannedDevices = updated
     }
 
     function applyStatus(text) {
@@ -114,7 +111,7 @@ QtObject {
             var payload = JSON.parse(text || "{}")
             root.powered = payload.powered === true
             root.deviceName = payload.connected_name || ""
-            root.devicesJson = JSON.stringify(payload.paired_devices || [])
+            root.devices = payload.paired_devices || []
             root.powerError = ""
         } catch (error) {
         }
@@ -242,8 +239,7 @@ QtObject {
         running: false
         onExited: () => {
             root.refresh()
-            root._scannedList = []
-            root.scannedJson = "[]"
+            root.scannedDevices = []
             root.autoConnect(true)
             root.requestScan("pair-refresh")
         }

--- a/src/Quickshell/desktop/DesktopIcons.qml
+++ b/src/Quickshell/desktop/DesktopIcons.qml
@@ -251,9 +251,19 @@ Item {
         appLoadProcess.running = true
     }
 
-    function checkDesktopSignature() {
-        if (!desktopSignatureProcess.running)
-            desktopSignatureProcess.running = true
+    function applyDesktopSignature(next) {
+        if (!next)
+            return
+
+        if (root.desktopSignature === "") {
+            root.desktopSignature = next
+            return
+        }
+
+        if (next !== root.desktopSignature) {
+            root.desktopSignature = next
+            refreshDebounce.restart()
+        }
     }
 
     Timer {
@@ -353,7 +363,7 @@ Item {
     Component.onCompleted: {
         stateLoadProcess.running = true
         refreshApps()
-        checkDesktopSignature()
+        desktopSignatureWatcher.running = true
     }
 
     function launchDesktop(path) {
@@ -414,14 +424,6 @@ Item {
     }
 
     Timer {
-        id: desktopSignatureTimer
-        interval: 5000
-        repeat: true
-        running: true
-        onTriggered: root.checkDesktopSignature()
-    }
-
-    Timer {
         id: refreshDebounce
         interval: 120
         repeat: false
@@ -429,28 +431,16 @@ Item {
     }
 
     Process {
-        id: desktopSignatureProcess
-        command: [
-            "python3",
-            "-c",
-            "import os,json\nfrom pathlib import Path\ncfg=Path(os.environ.get('XDG_CONFIG_HOME', Path.home()/'.config'))/'user-dirs.dirs'\nd=Path.home()/'Desktop'\ntry:\n    for line in cfg.read_text(encoding='utf-8', errors='ignore').splitlines():\n        line=line.strip()\n        if line.startswith('XDG_DESKTOP_DIR='):\n            d=Path(os.path.expandvars(line.split('=',1)[1].strip().strip('\"').replace('$HOME', str(Path.home()))))\n            break\nexcept Exception:\n    pass\nitems=[]\nif d.exists():\n    for p in sorted(d.glob('*.desktop')):\n        try: items.append([p.name, p.stat().st_mtime_ns, p.stat().st_size])\n        except OSError: pass\nprint(json.dumps(items, ensure_ascii=False))"
-        ]
+        id: desktopSignatureWatcher
+        command: ["python3", root.scriptPath, "--watch-signature"]
         running: false
-        stdout: StdioCollector { id: desktopSignatureStdout }
-        onExited: function(exitCode) {
-            if (exitCode !== 0)
-                return
-
-            var next = desktopSignatureStdout.text || ""
-            if (root.desktopSignature === "") {
-                root.desktopSignature = next
-                return
-            }
-
-            if (next !== root.desktopSignature) {
-                root.desktopSignature = next
-                refreshDebounce.restart()
-            }
+        stdout: SplitParser {
+            splitMarker: "\n"
+            onRead: data => root.applyDesktopSignature(data.trim())
+        }
+        onExited: function() {
+            if (root.stateLoaded)
+                Qt.callLater(() => { desktopSignatureWatcher.running = true })
         }
     }
 

--- a/src/Quickshell/desktop/DesktopIcons.qml
+++ b/src/Quickshell/desktop/DesktopIcons.qml
@@ -430,6 +430,16 @@ Item {
         onTriggered: root.refreshApps()
     }
 
+    Timer {
+        id: desktopSignatureRestartTimer
+        interval: 2000
+        repeat: false
+        onTriggered: {
+            if (root.stateLoaded && !desktopSignatureWatcher.running)
+                desktopSignatureWatcher.running = true
+        }
+    }
+
     Process {
         id: desktopSignatureWatcher
         command: ["python3", root.scriptPath, "--watch-signature"]
@@ -440,7 +450,7 @@ Item {
         }
         onExited: function() {
             if (root.stateLoaded)
-                Qt.callLater(() => { desktopSignatureWatcher.running = true })
+                desktopSignatureRestartTimer.restart()
         }
     }
 

--- a/src/Quickshell/desktop/app_index.py
+++ b/src/Quickshell/desktop/app_index.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import argparse
+import ctypes
 import json
+import os
+import select
 import sys
+import time
 from pathlib import Path
 
 BRIDGE_DIR = Path(__file__).resolve().parents[2] / "Core" / "bridge"
@@ -14,6 +18,16 @@ if str(BRIDGE_DIR) not in sys.path:
 from astrea_shared import FALLBACK_ICON, atomic_write_json, atomic_write_text, parse_desktop_file, xdg_desktop_dir
 
 MAX_APPS = 64
+IN_CLOSE_WRITE = 0x00000008
+IN_MOVED_TO = 0x00000080
+IN_CREATE = 0x00000100
+IN_DELETE = 0x00000200
+IN_DELETE_SELF = 0x00000400
+IN_MOVE_SELF = 0x00000800
+IN_ONLYDIR = 0x01000000
+IN_NONBLOCK = 0x00000800
+IN_CLOEXEC = 0x00080000
+WATCH_MASK = IN_CLOSE_WRITE | IN_MOVED_TO | IN_CREATE | IN_DELETE | IN_DELETE_SELF | IN_MOVE_SELF
 
 
 def collect_apps() -> list[dict[str, str]]:
@@ -52,6 +66,82 @@ def collect_apps() -> list[dict[str, str]]:
     return items
 
 
+def desktop_signature() -> list[list[object]]:
+    desktop_dir = xdg_desktop_dir()
+    items: list[list[object]] = []
+    if not desktop_dir.exists():
+        return items
+    for path in sorted(desktop_dir.glob("*.desktop")):
+        try:
+            stat = path.stat()
+        except OSError:
+            continue
+        items.append([path.name, stat.st_mtime_ns, stat.st_size])
+    return items
+
+
+def signature_json() -> str:
+    return json.dumps(desktop_signature(), ensure_ascii=False, separators=(",", ":"))
+
+
+def emit_signature(last: str | None = None) -> str:
+    current = signature_json()
+    if current != last:
+        print(current, flush=True)
+    return current
+
+
+def inotify_watch() -> int | None:
+    desktop_dir = xdg_desktop_dir()
+    if not desktop_dir.exists():
+        return None
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        fd = libc.inotify_init1(IN_NONBLOCK | IN_CLOEXEC)
+        if fd < 0:
+            return None
+        wd = libc.inotify_add_watch(fd, os.fsencode(desktop_dir), WATCH_MASK | IN_ONLYDIR)
+        if wd < 0:
+            os.close(fd)
+            return None
+        return fd
+    except (AttributeError, OSError):
+        return None
+
+
+def drain_inotify(fd: int) -> None:
+    try:
+        while os.read(fd, 4096):
+            pass
+    except BlockingIOError:
+        return
+    except OSError:
+        return
+
+
+def watch_signatures() -> None:
+    last = emit_signature(None)
+    fd = inotify_watch()
+    if fd is None:
+        while True:
+            time.sleep(5)
+            last = emit_signature(last)
+
+    poller = select.poll()
+    poller.register(fd, select.POLLIN | select.POLLERR | select.POLLHUP)
+    try:
+        while True:
+            events = poller.poll(30000)
+            if not events:
+                last = emit_signature(last)
+                continue
+            drain_inotify(fd)
+            time.sleep(0.08)
+            last = emit_signature(last)
+    finally:
+        os.close(fd)
+
+
 def write_js(items: list[dict[str, str]], output_path: Path) -> None:
     payload = json.dumps(items, ensure_ascii=False, indent=2)
     atomic_write_text(output_path, f"var APPS = {payload};\n")
@@ -62,15 +152,24 @@ def write_json(items: list[dict[str, str]], output_path: Path) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Generate the desktop icon list from the XDG desktop folder.")
+    parser = argparse.ArgumentParser(description="Generate or watch the desktop icon list from the XDG desktop folder.")
     parser.add_argument("--json", action="store_true", help="print the generated app list as JSON")
     parser.add_argument("--write", action="store_true", help="write apps.js and apps.json")
+    parser.add_argument("--signature", action="store_true", help="print the current desktop shortcut signature as JSON")
+    parser.add_argument("--watch-signature", action="store_true", help="stream desktop shortcut signatures when the desktop folder changes")
     parser.add_argument("--max-apps", type=int, default=MAX_APPS, help="maximum number of apps to emit")
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
+    if args.watch_signature:
+        watch_signatures()
+        return
+    if args.signature:
+        print(signature_json())
+        return
+
     items = collect_apps()[:max(1, args.max_apps)]
     script_dir = Path(__file__).resolve().parent
 

--- a/src/Quickshell/island/MusicMonitor.qml
+++ b/src/Quickshell/island/MusicMonitor.qml
@@ -27,8 +27,23 @@ Item {
 
     property bool _playerMonitorStarting: false
     property bool _playerAvailabilityResetting: false
+    property var _dominantColorCache: ({})
+    property var _remoteArtCache: ({})
 
     function setDominantColor(path) {
+        if (!path) {
+            dominantCol = "#ffffff"
+            return
+        }
+
+        if (_dominantColorCache[path]) {
+            dominantCol = _dominantColorCache[path]
+            return
+        }
+
+        if (dominantColor.running && dominantColor.imagePath === path)
+            return
+
         dominantColor.imagePath = path
         dominantColor.running = false
         Qt.callLater(() => { dominantColor.running = true })
@@ -130,10 +145,13 @@ Item {
     }
 
     function ensureMusicBars() {
-        if (!musicBarsProcess.running) {
+        if (!root.isPlaying || !root.shouldDisplayMusic) {
             musicBarsProcess.running = false
-            Qt.callLater(() => { musicBarsProcess.running = true })
+            return
         }
+
+        if (!musicBarsProcess.running)
+            Qt.callLater(() => { if (root.isPlaying && root.shouldDisplayMusic) musicBarsProcess.running = true })
     }
 
     Process {
@@ -147,7 +165,11 @@ Item {
                 if (p.length !== 3) return
                 var r = parseInt(p[0]), g = parseInt(p[1]), b = parseInt(p[2])
                 if (isNaN(r) || isNaN(g) || isNaN(b)) return
-                root.dominantCol = Qt.rgba(r / 255, g / 255, b / 255, 1).toString()
+                var color = Qt.rgba(r / 255, g / 255, b / 255, 1).toString()
+                root.dominantCol = color
+                var cache = Object.assign({}, root._dominantColorCache)
+                cache[dominantColor.imagePath] = color
+                root._dominantColorCache = cache
             }
         }
     }
@@ -234,11 +256,18 @@ Item {
                     root.artPath = ""
                     root.dominantCol = "#ffffff"
                 } else if (artUrl.startsWith("http")) {
-                    fetchArt.running = false
-                    Qt.callLater(() => {
-                        fetchArt.url = artUrl
-                        fetchArt.running = true
-                    })
+                    if (root._remoteArtCache[artUrl]) {
+                        var cached = root._remoteArtCache[artUrl]
+                        root.artSource = "file://" + cached + "?" + Date.now()
+                        root.artPath = cached
+                        root.setDominantColor(cached)
+                    } else if (!(fetchArt.running && fetchArt.url === artUrl)) {
+                        fetchArt.running = false
+                        Qt.callLater(() => {
+                            fetchArt.url = artUrl
+                            fetchArt.running = true
+                        })
+                    }
                 } else {
                     root.artSource = artUrl
                     root.artPath = artUrl.replace("file://", "").split("?")[0]
@@ -290,6 +319,9 @@ Item {
                 if (!path) return
                 root.artSource = "file://" + path + "?" + Date.now()
                 root.artPath = path
+                var cache = Object.assign({}, root._remoteArtCache)
+                cache[fetchArt.url] = path
+                root._remoteArtCache = cache
                 root.setDominantColor(path)
             }
         }

--- a/src/Quickshell/notifications/Notifications.qml
+++ b/src/Quickshell/notifications/Notifications.qml
@@ -23,6 +23,7 @@ PanelWindow {
     WlrLayershell.exclusiveZone: -1
 
     property string statePath: Qt.resolvedUrl("state.json").toString().replace("file://", "")
+    readonly property int maxRenderedNotifications: 8
 
     function modelIndexFor(notificationId) {
         for (let index = 0; index < notificationModel.count; index++) {
@@ -46,8 +47,9 @@ PanelWindow {
 
     function syncNotifications(items) {
         const seen = {}
+        const liveItems = (items || []).slice(-root.maxRenderedNotifications)
 
-        for (const item of items) {
+        for (const item of liveItems) {
             const notification = normalizedNotification(item)
             seen[notification.notificationId] = true
 
@@ -63,6 +65,9 @@ PanelWindow {
             if (!seen[currentId])
                 notificationModel.remove(index)
         }
+
+        while (notificationModel.count > root.maxRenderedNotifications)
+            notificationModel.remove(0)
     }
 
     function closeNotification(notificationId) {

--- a/src/Quickshell/shell.qml
+++ b/src/Quickshell/shell.qml
@@ -4,6 +4,9 @@ import Quickshell
 import Quickshell.Io
 import QtQuick
 import "./bar"
+import "./bar/modules/audio"
+import "./bar/modules/network"
+import "./bar/modules/bluetooth"
 import "./island"
 import "./notifications"
 import "./spotlight"
@@ -17,6 +20,18 @@ ShellRoot {
 
     MusicMonitor {
         id: musicMonitor
+    }
+
+    NetworkProcess {
+        id: networkStatus
+    }
+
+    BluetoothProcess {
+        id: bluetoothStatus
+    }
+
+    AudioProcess {
+        id: audioStatus
     }
 
     Process {
@@ -56,6 +71,9 @@ ShellRoot {
             required property var modelData
             screen: modelData
             sharedMusicState: musicMonitor
+            sharedNetworkState: networkStatus
+            sharedBluetoothState: bluetoothStatus
+            sharedAudioState: audioStatus
         }
     }
 

--- a/src/Quickshell/spotlight/Spotlight.qml
+++ b/src/Quickshell/spotlight/Spotlight.qml
@@ -250,6 +250,8 @@ ShellRoot {
         readonly property int weatherStaleMs: 1800000
         property double weatherLastRefreshMs: 0
         property string pendingQuery: ""
+        property var pendingLaunchEntry: null
+        property string execArgvBuffer: ""
 
         function toggle() {
             if (open) {
@@ -426,62 +428,6 @@ ShellRoot {
             results = items.slice(0, 6).map(item => item.entry)
         }
 
-        function parseExecForArgv(commandText) {
-            var args = []
-            var current = ""
-            var quote = ""
-            var argStarted = false
-            var suppressArg = false
-
-            function finishArg() {
-                if (argStarted && !suppressArg)
-                    args.push(current)
-                current = ""
-                argStarted = false
-                suppressArg = false
-            }
-
-            for (var i = 0; i < commandText.length; i++) {
-                var ch = commandText.charAt(i)
-                if ((ch === "'" || ch === '"') && quote === "") {
-                    quote = ch
-                    argStarted = true
-                } else if (ch === quote) {
-                    quote = ""
-                    argStarted = true
-                } else if (ch === "\\") {
-                    i++
-                    if (i < commandText.length) {
-                        current += commandText.charAt(i)
-                        argStarted = true
-                        suppressArg = false
-                    }
-                } else if (ch === "%") {
-                    argStarted = true
-                    i++
-                    var code = i < commandText.length ? commandText.charAt(i) : ""
-                    if (code === "%") {
-                        current += "%"
-                        suppressArg = false
-                    } else if ("fFuUick".indexOf(code) >= 0) {
-                        if (current.length === 0)
-                            suppressArg = true
-                    }
-                } else if (/\s/.test(ch) && quote === "") {
-                    finishArg()
-                } else {
-                    current += ch
-                    argStarted = true
-                    suppressArg = false
-                }
-            }
-
-            if (quote !== "")
-                return []
-            finishArg()
-            return args
-        }
-
         function launch(index) {
             if (index < 0 || index >= results.length) return
             let entry = results[index]
@@ -497,16 +443,20 @@ ShellRoot {
                 var desktopId = desktopIdForEntry(entry)
                 if (desktopId) {
                     launchProc.command = [astreaLaunch, "--desktop", desktopId]
-                } else {
-                    var commandText = entry.exec || entry.execString || ""
-                    var argv = commandText ? parseExecForArgv(commandText) : []
-                    launchProc.command = argv.length > 0 ? [astreaLaunch, "--argv-json", JSON.stringify(argv)] : []
-                }
-                if (launchProc.command.length > 0) {
                     launchProc.running = false
                     launchProc.running = true
-                } else if (standalone && !usageSaveProc.running) {
-                    Qt.quit()
+                } else {
+                    var commandText = entry.exec || entry.execString || ""
+                    if (!commandText) {
+                        if (standalone && !usageSaveProc.running)
+                            Qt.quit()
+                        return
+                    }
+                    pendingLaunchEntry = entry
+                    execArgvBuffer = ""
+                    execArgvProc.command = [spotlightCli, "exec-argv", commandText]
+                    execArgvProc.running = false
+                    execArgvProc.running = true
                 }
             })
         }
@@ -560,6 +510,36 @@ ShellRoot {
                 if (!spotlight.quitAfterUsageSave) return
                 spotlight.quitAfterUsageSave = false
                 Qt.quit()
+            }
+        }
+
+        property var execArgvProc: Process {
+            id: execArgvProc
+            command: []
+            running: false
+            stdout: SplitParser {
+                onRead: data => spotlight.execArgvBuffer += data
+            }
+            onExited: (code, _) => {
+                if (code !== 0) {
+                    if (spotlight.standalone && !spotlight.usageSaveProc.running)
+                        Qt.quit()
+                    return
+                }
+                try {
+                    var argv = JSON.parse(spotlight.execArgvBuffer || "[]")
+                    launchProc.command = Array.isArray(argv) && argv.length > 0 ? [spotlight.astreaLaunch, "--argv-json", JSON.stringify(argv)] : []
+                } catch (e) {
+                    launchProc.command = []
+                }
+                spotlight.pendingLaunchEntry = null
+                spotlight.execArgvBuffer = ""
+                if (launchProc.command.length > 0) {
+                    launchProc.running = false
+                    launchProc.running = true
+                } else if (spotlight.standalone && !spotlight.usageSaveProc.running) {
+                    Qt.quit()
+                }
             }
         }
 

--- a/src/System/scripts/astrea-spotlight
+++ b/src/System/scripts/astrea-spotlight
@@ -46,6 +46,59 @@ def read_json(path: Path, fallback: object) -> object:
         return fallback
 
 
+
+def parse_exec_line(line: str) -> list[str]:
+    args: list[str] = []
+    current = ""
+    quote = ""
+    arg_started = False
+    suppress_arg = False
+
+    def finish_arg() -> None:
+        nonlocal current, arg_started, suppress_arg
+        if arg_started and not suppress_arg:
+            args.append(current)
+        current = ""
+        arg_started = False
+        suppress_arg = False
+
+    index = 0
+    while index < len(line):
+        ch = line[index]
+        if ch in ("'", '"') and not quote:
+            quote = ch
+            arg_started = True
+        elif ch == quote:
+            quote = ""
+            arg_started = True
+        elif ch == "\\":
+            index += 1
+            if index < len(line):
+                current += line[index]
+                arg_started = True
+                suppress_arg = False
+        elif ch == "%":
+            arg_started = True
+            index += 1
+            code = line[index] if index < len(line) else ""
+            if code == "%":
+                current += "%"
+                suppress_arg = False
+            elif code in "fFuUick" and not current:
+                suppress_arg = True
+        elif ch.isspace() and not quote:
+            finish_arg()
+        else:
+            current += ch
+            arg_started = True
+            suppress_arg = False
+        index += 1
+
+    if quote:
+        return []
+    finish_arg()
+    return args
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Astrea Spotlight state helper")
     sub = parser.add_subparsers(dest="command", required=True)
@@ -53,6 +106,8 @@ def main() -> int:
     save = sub.add_parser("usage-save")
     save.add_argument("json_data")
     sub.add_parser("config")
+    exec_argv = sub.add_parser("exec-argv")
+    exec_argv.add_argument("exec_text")
     args = parser.parse_args()
 
     if args.command == "usage-load":
@@ -69,6 +124,9 @@ def main() -> int:
             print(json.dumps(default, ensure_ascii=False))
         else:
             print(json.dumps(read_json(path, default), ensure_ascii=False))
+        return 0
+    if args.command == "exec-argv":
+        print(json.dumps(parse_exec_line(args.exec_text), ensure_ascii=False))
         return 0
     return 2
 


### PR DESCRIPTION
### Motivation
- Reduce Quickshell RAM and process/timer churn by preventing per-monitor watcher/process duplication and moving backend-like work out of QML. 
- Keep visible UI behavior identical while shifting state collection and heavy work to shared helpers and single long-lived watchers. 

### Description
- Centralize network, Bluetooth and audio state in the `ShellRoot` and pass shared state objects into each `Bar` so watchers are not instantiated per screen (`src/Quickshell/shell.qml`, `src/Quickshell/bar/Bar.qml`).
- Add a shared `AudioProcess` QML helper that reads `~/.local/state/Astrea/status/audio.json` and exposes `level`/`muted` plus `setVolume` so bars use a single audio backend (`src/Quickshell/bar/modules/audio/AudioProcess.qml`).
- Move desktop-icon change detection out of QML into `app_index.py` with an inotify-backed watcher and polling fallback that emits signatures; `DesktopIcons.qml` now consumes streamed signatures via `--watch-signature` and debounces refreshes (`src/Quickshell/desktop/app_index.py`, `src/Quickshell/desktop/DesktopIcons.qml`).
- Cap live rendered notifications to the latest 8 items so spam cannot create unlimited QML delegates (`src/Quickshell/notifications/Notifications.qml`).
- Reduce Music monitor churn by caching dominant-color and remote-art fetch results and only running music-bars while music is actively playing/visible (`src/Quickshell/island/MusicMonitor.qml`).
- Move Exec parsing out of Spotlight QML into the shared helper `astrea-spotlight exec-argv`, and update Spotlight to request parsed argv from that helper before launching, keeping QML UI-only for orchestration (`src/System/scripts/astrea-spotlight`, `src/Quickshell/spotlight/Spotlight.qml`).
- Improve Bluetooth process internals by using arrays/objects for devices and scanned lists and stringify only at compatibility boundaries to avoid duplicated JSON state construction (`src/Quickshell/bar/modules/bluetooth/BluetoothProcess.qml`).

### Testing
- Ran `git diff --check` with no issues (passed). 
- Checked Python compilation with `python3 -m py_compile src/Quickshell/desktop/app_index.py src/System/scripts/astrea-spotlight` (passed). 
- Exercised the desktop helper flows: `python3 src/Quickshell/desktop/app_index.py --json` produced valid output and `python3 src/Quickshell/desktop/app_index.py --watch-signature` was exercised (watch mode observed output; environment `timeout` was used during validation). 
- Verified Spotlight Exec parsing helper with `python3 src/System/scripts/astrea-spotlight exec-argv '<exec>'` and observed correct argv results (passed). 
- `qmllint` and `quickshell -p` checks were listed but not executed because those tools are not available in the test environment (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0722fc7ae0832697956d6b541c5830)