### PR TITLE
Explorer: add helper-backed archive/trash/image ops, JSON file-op events, QML integration and tests

### DIFF
--- a/scripts/run_refactor_checks.sh
+++ b/scripts/run_refactor_checks.sh
@@ -4,3 +4,5 @@ python3 src/System/i18n/validate_i18n.py
 python3 src/System/i18n/test_i18n.py
 python3 src/Core/bridge/test_state_json.py
 python3 src/Quickshell/desktop/test_app_index.py
+python3 -m unittest src/Apps/Explorer/tests/test_explorer_helper.py
+(cd src/Core/bridge/apps/explorer && cargo test -q)

--- a/src/Apps/Explorer/RELIABILITY_MANUAL_CHECKLIST.md
+++ b/src/Apps/Explorer/RELIABILITY_MANUAL_CHECKLIST.md
@@ -1,0 +1,16 @@
+# Explorer Reliability Manual Checklist
+
+- Copy file and folder.
+- Cut file and folder.
+- Paste with conflict: replace.
+- Paste with conflict: keep both.
+- Paste with conflict: merge folder.
+- Paste with conflict: skip.
+- Move to trash (single and multiple items).
+- Restore from trash (normal, missing original directory, destination conflict).
+- Empty trash.
+- Paste image from clipboard (PNG/JPG, collision naming).
+- Extract archive (zip, tar.gz; rar/7z when tools available).
+- Compress folder (zip, tar, tar.gz, tar.xz; rar when tool available).
+- Verify folder refreshes after each operation.
+- Verify extracted folder is auto-selected/revealed.

--- a/src/Apps/Explorer/explorer_helper.py
+++ b/src/Apps/Explorer/explorer_helper.py
@@ -394,7 +394,7 @@ def trash_items(trash_files_text: str, trash_info_text: str, paths: list[str]) -
         if not source.exists():
             continue
         destination = _unique_target(trash_files, source.name)
-        os.rename(source, destination)
+        shutil.move(str(source), str(destination))
         info_path = trash_info / f"{destination.name}.trashinfo"
         info_path.write_text(
             "[Trash Info]\n"
@@ -433,7 +433,7 @@ def restore_trash_items(trash_info_text: str, fallback_dir_text: str, paths: lis
             parent = fallback_dir
 
         final_target = _unique_target(parent, target.name)
-        os.rename(trashed, final_target)
+        shutil.move(str(trashed), str(final_target))
         info_path.unlink(missing_ok=True)
 
 

--- a/src/Apps/Explorer/explorer_helper.py
+++ b/src/Apps/Explorer/explorer_helper.py
@@ -10,6 +10,7 @@ import signal
 import shutil
 import subprocess
 import time
+import urllib.parse
 from pathlib import Path
 
 
@@ -111,14 +112,221 @@ def copy_uri_list(paths: list[str]) -> None:
     payload = "".join(f"file://{path}\n" for path in paths)
     subprocess.run(["wl-copy", "--type", "text/uri-list"], input=payload, text=True, check=True)
 
+IMAGE_MIME_EXTENSIONS = {
+    "image/png": "png",
+    "image/jpeg": "jpg",
+    "image/webp": "webp",
+    "image/gif": "gif",
+    "image/bmp": "bmp",
+    "image/tiff": "tiff",
+    "image/x-portable-pixmap": "ppm",
+    "image/x-portable-graymap": "pgm",
+    "image/x-portable-bitmap": "pbm",
+}
+ARCHIVE_FORMAT_EXTENSIONS = {"zip": "zip", "rar": "rar", "tar": "tar", "tar.gz": "tar.gz", "tar.xz": "tar.xz"}
 
-def scan_conflicts(destination_text: str, paths: list[str]) -> None:
+
+def image_extension_for_mime(mime_type: str) -> str:
+    return IMAGE_MIME_EXTENSIONS.get(mime_type, "png")
+
+
+def paste_image(destination_dir_text: str, mime_type: str, paste_runner=None) -> str:
+    destination_dir = Path(destination_dir_text).expanduser()
+    if not destination_dir.is_dir():
+        raise SystemExit(2)
+
+    ext = image_extension_for_mime(mime_type)
+    stamp = time.strftime("%Y-%m-%d %H-%M-%S")
+    base_name = f"Pasted Image {stamp}"
+    target = _unique_target(destination_dir, f"{base_name}.{ext}")
+
+    runner = paste_runner or subprocess.run
+    result = runner(
+        ["wl-paste", "--no-newline", "--type", mime_type],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    target.write_bytes(result.stdout)
+    print(target)
+    return str(target)
+
+
+def _json_event(payload: dict[str, object]) -> None:
+    import json
+    print(json.dumps(payload, ensure_ascii=False), flush=True)
+
+
+def _error_code_from_exception(exc: Exception) -> str:
+    msg = str(exc).lower()
+    if "permission denied" in msg:
+        return "permission_denied"
+    if "no such file" in msg or "not found" in msg:
+        return "not_found"
+    return "operation_failed"
+
+
+def _pick_extractor(archive_path: Path, which_runner=shutil.which) -> list[str]:
+    lower = archive_path.name.lower()
+    if lower.endswith(".zip"):
+        if which_runner("unzip"):
+            return ["unzip", "-o", str(archive_path), "-d"]
+        if which_runner("bsdtar"):
+            return ["bsdtar", "-xf", str(archive_path), "-C"]
+        raise RuntimeError("missing_tool: unzip/bsdtar")
+    if lower.endswith(".rar"):
+        if which_runner("unrar"):
+            return ["unrar", "x", "-o+", str(archive_path)]
+        if which_runner("7z"):
+            return ["7z", "x", "-y", str(archive_path)]
+        raise RuntimeError("missing_tool: unrar/7z")
+    if lower.endswith(".7z"):
+        if which_runner("7z"):
+            return ["7z", "x", "-y", str(archive_path)]
+        raise RuntimeError("missing_tool: 7z")
+    if which_runner("bsdtar"):
+        return ["bsdtar", "-xf", str(archive_path), "-C"]
+    if which_runner("tar"):
+        return ["tar", "-xf", str(archive_path), "-C"]
+    raise RuntimeError("missing_tool: bsdtar/tar")
+
+
+def extract_archive(archive_path_text: str, folder_name: str, run_cmd=None, which_runner=shutil.which) -> None:
+    archive_path = Path(archive_path_text).expanduser()
+    if not archive_path.exists():
+        _json_event({"event": "error", "mode": "extract", "code": "not_found", "message": "archive not found"})
+        raise SystemExit(1)
+    parent = archive_path.parent
+    destination = _unique_target(parent, folder_name or archive_path.name)
+    destination.mkdir(parents=True, exist_ok=True)
+    _json_event({"event": "start", "mode": "extract", "name": archive_path.name, "destination": str(destination), "total": 1})
+    runner = run_cmd or subprocess.run
+    try:
+        cmd = _pick_extractor(archive_path, which_runner)
+        if cmd[0] == "unrar":
+            runner(cmd + [str(destination) + "/"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        elif cmd[0] == "7z":
+            runner(cmd + [f"-o{destination}"], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        else:
+            runner(cmd + [str(destination)], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        _json_event({"event": "progress", "mode": "extract", "done": 1, "total": 1, "percent": 100})
+        _json_event({"event": "done", "mode": "extract", "destination": str(destination), "done": 1, "total": 1, "percent": 100})
+    except RuntimeError as exc:
+        _json_event({"event": "error", "mode": "extract", "code": "missing_tool", "message": str(exc), "destination": str(destination)})
+        raise SystemExit(1)
+    except Exception as exc:
+        _json_event({"event": "error", "mode": "extract", "code": _error_code_from_exception(exc), "message": str(exc), "destination": str(destination)})
+        raise SystemExit(1)
+
+
+def compress_folder(folder_path_text: str, archive_format: str, run_cmd=None, which_runner=shutil.which) -> None:
+    folder = Path(folder_path_text).expanduser()
+    if not folder.is_dir():
+        _json_event({"event": "error", "mode": "compress", "code": "not_found", "message": "folder not found"})
+        raise SystemExit(1)
+    ext = ARCHIVE_FORMAT_EXTENSIONS.get(archive_format)
+    if not ext:
+        _json_event({"event": "error", "mode": "compress", "code": "invalid_format", "message": "unsupported format"})
+        raise SystemExit(1)
+    target = _unique_target(folder.parent, f"{folder.name}.{ext}")
+    _json_event({"event": "start", "mode": "compress", "name": folder.name, "destination": str(target), "total": 1})
+    runner = run_cmd or subprocess.run
+    try:
+        if archive_format == "zip":
+            if not which_runner("zip"): raise RuntimeError("zip")
+            runner(["zip", "-qr", str(target), folder.name], check=True, cwd=str(folder.parent), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        elif archive_format == "rar":
+            if not which_runner("rar"): raise RuntimeError("rar")
+            runner(["rar", "a", "-idq", str(target), folder.name], check=True, cwd=str(folder.parent), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        else:
+            if not which_runner("tar"): raise RuntimeError("tar")
+            args = {"tar": ["tar", "-cf"], "tar.gz": ["tar", "-czf"], "tar.xz": ["tar", "-cJf"]}[archive_format]
+            runner(args + [str(target), folder.name], check=True, cwd=str(folder.parent), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        _json_event({"event": "progress", "mode": "compress", "done": 1, "total": 1, "percent": 100})
+        _json_event({"event": "done", "mode": "compress", "destination": str(target), "done": 1, "total": 1, "percent": 100})
+    except RuntimeError as exc:
+        _json_event({"event": "error", "mode": "compress", "code": "missing_tool", "message": f"missing_tool: {exc}", "destination": str(target)})
+        raise SystemExit(1)
+    except Exception as exc:
+        _json_event({"event": "error", "mode": "compress", "code": _error_code_from_exception(exc), "message": str(exc), "destination": str(target)})
+        raise SystemExit(1)
+
+
+def _path_type(path: Path) -> str:
+    try:
+        path.lstat()
+    except OSError:
+        return "missing"
+    if path.is_symlink():
+        return "symlink"
+    if path.is_dir():
+        return "directory"
+    if path.is_file():
+        return "file"
+    return "other"
+
+
+def _conflict_record(source: Path, destination: Path) -> dict[str, object] | None:
+    target = destination / source.name
+    if source == target:
+        return {
+            "source": str(source),
+            "destination": str(target),
+            "name": source.name,
+            "source_type": _path_type(source),
+            "destination_type": _path_type(target),
+            "conflict_kind": "same-path",
+            "supported_policies": ["skip"],
+        }
+    if not target.exists():
+        return None
+
+    source_type = _path_type(source)
+    destination_type = _path_type(target)
+    if source_type == "directory" and destination_type == "directory":
+        conflict_kind = "directory-merge"
+        policies = ["skip", "overwrite", "keep-both", "merge"]
+    elif source_type == "file" and destination_type == "file":
+        conflict_kind = "file-replace"
+        policies = ["skip", "overwrite", "keep-both", "rename"]
+    elif source_type == "directory" and destination_type == "file":
+        conflict_kind = "directory-over-file"
+        policies = ["skip"]
+    elif source_type == "file" and destination_type == "directory":
+        conflict_kind = "file-over-directory"
+        policies = ["skip"]
+    else:
+        conflict_kind = "name-collision"
+        policies = ["skip", "keep-both"]
+
+    return {
+        "source": str(source),
+        "destination": str(target),
+        "name": source.name,
+        "source_type": source_type,
+        "destination_type": destination_type,
+        "conflict_kind": conflict_kind,
+        "supported_policies": policies,
+    }
+
+
+def scan_conflicts(destination_text: str, paths: list[str], output_format: str = "names") -> None:
+    import json
+
     destination = Path(destination_text).expanduser()
+    conflicts: list[dict[str, object]] = []
     for raw in paths:
         source = Path(raw).expanduser()
-        target = destination / source.name
-        if source != target and target.exists():
-            print(source.name)
+        record = _conflict_record(source, destination)
+        if record is not None:
+            conflicts.append(record)
+
+    if output_format == "json":
+        print(json.dumps(conflicts, ensure_ascii=False))
+        return
+
+    for item in conflicts:
+        print(item["name"])
 
 
 IN_CLOSE_WRITE = 0x00000008
@@ -151,6 +359,101 @@ def _dir_signature(path: Path) -> tuple:
 
 def _emit_changed() -> None:
     print("changed", flush=True)
+
+
+def _unique_target(parent: Path, name: str) -> Path:
+    candidate = parent / name
+    if not candidate.exists():
+        return candidate
+    stem, ext = os.path.splitext(name)
+    index = 2
+    while True:
+        candidate = parent / f"{stem} {index}{ext}"
+        if not candidate.exists():
+            return candidate
+        index += 1
+
+
+def _encode_trash_path(path: Path) -> str:
+    return urllib.parse.quote(str(path), safe="/")
+
+
+def _decode_trash_path(path_text: str) -> str:
+    return urllib.parse.unquote(path_text)
+
+
+def trash_items(trash_files_text: str, trash_info_text: str, paths: list[str]) -> None:
+    trash_files = Path(trash_files_text).expanduser()
+    trash_info = Path(trash_info_text).expanduser()
+    trash_files.mkdir(parents=True, exist_ok=True)
+    trash_info.mkdir(parents=True, exist_ok=True)
+    deletion_date = time.strftime("%Y-%m-%dT%H:%M:%S")
+
+    for raw in paths:
+        source = Path(raw).expanduser()
+        if not source.exists():
+            continue
+        destination = _unique_target(trash_files, source.name)
+        os.rename(source, destination)
+        info_path = trash_info / f"{destination.name}.trashinfo"
+        info_path.write_text(
+            "[Trash Info]\n"
+            f"Path={_encode_trash_path(source)}\n"
+            f"DeletionDate={deletion_date}\n",
+            encoding="utf-8",
+        )
+
+
+def restore_trash_items(trash_info_text: str, fallback_dir_text: str, paths: list[str]) -> None:
+    trash_info = Path(trash_info_text).expanduser()
+    fallback_dir = Path(fallback_dir_text).expanduser()
+    fallback_dir.mkdir(parents=True, exist_ok=True)
+
+    for raw in paths:
+        trashed = Path(raw).expanduser()
+        if not trashed.exists():
+            continue
+        info_path = trash_info / f"{trashed.name}.trashinfo"
+
+        original = ""
+        if info_path.exists():
+            try:
+                for line in info_path.read_text(encoding="utf-8").splitlines():
+                    if line.startswith("Path="):
+                        original = _decode_trash_path(line[5:])
+                        break
+            except OSError:
+                original = ""
+
+        target = Path(original) if original else (fallback_dir / trashed.name)
+        parent = target.parent
+        try:
+            parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            parent = fallback_dir
+
+        final_target = _unique_target(parent, target.name)
+        os.rename(trashed, final_target)
+        info_path.unlink(missing_ok=True)
+
+
+def empty_trash(trash_files_text: str, trash_info_text: str) -> None:
+    trash_files = Path(trash_files_text).expanduser()
+    trash_info = Path(trash_info_text).expanduser()
+    trash_files.mkdir(parents=True, exist_ok=True)
+    trash_info.mkdir(parents=True, exist_ok=True)
+
+    for entry in trash_files.iterdir():
+        if entry.is_dir() and not entry.is_symlink():
+            shutil.rmtree(entry, ignore_errors=True)
+        else:
+            entry.unlink(missing_ok=True)
+
+    for entry in trash_info.iterdir():
+        if entry.is_dir() and not entry.is_symlink():
+            shutil.rmtree(entry, ignore_errors=True)
+        else:
+            entry.unlink(missing_ok=True)
 
 
 def _drain_inotify(fd: int) -> None:
@@ -238,9 +541,34 @@ def parse_args() -> argparse.Namespace:
     conflicts = sub.add_parser("scan-conflicts")
     conflicts.add_argument("destination")
     conflicts.add_argument("paths", nargs="+")
+    conflicts.add_argument("--format", choices=["names", "json"], default="names")
 
     monitor = sub.add_parser("monitor-dir")
     monitor.add_argument("path")
+
+    trash = sub.add_parser("trash")
+    trash.add_argument("trash_files")
+    trash.add_argument("trash_info")
+    trash.add_argument("paths", nargs="+")
+
+    restore = sub.add_parser("restore-trash")
+    restore.add_argument("trash_info")
+    restore.add_argument("fallback_dir")
+    restore.add_argument("paths", nargs="+")
+
+    empty = sub.add_parser("empty-trash")
+    empty.add_argument("trash_files")
+    empty.add_argument("trash_info")
+
+    paste_image_cmd = sub.add_parser("paste-image")
+    paste_image_cmd.add_argument("destination_dir")
+    paste_image_cmd.add_argument("mime_type")
+    extract_cmd = sub.add_parser("extract-archive")
+    extract_cmd.add_argument("archive_path")
+    extract_cmd.add_argument("folder_name")
+    compress_cmd = sub.add_parser("compress-folder")
+    compress_cmd.add_argument("folder_path")
+    compress_cmd.add_argument("archive_format")
 
     return parser.parse_args()
 
@@ -264,9 +592,21 @@ def main() -> None:
     elif args.command == "copy-uri-list":
         copy_uri_list(args.paths)
     elif args.command == "scan-conflicts":
-        scan_conflicts(args.destination, args.paths)
+        scan_conflicts(args.destination, args.paths, args.format)
     elif args.command == "monitor-dir":
         monitor_dir(args.path)
+    elif args.command == "trash":
+        trash_items(args.trash_files, args.trash_info, args.paths)
+    elif args.command == "restore-trash":
+        restore_trash_items(args.trash_info, args.fallback_dir, args.paths)
+    elif args.command == "empty-trash":
+        empty_trash(args.trash_files, args.trash_info)
+    elif args.command == "paste-image":
+        paste_image(args.destination_dir, args.mime_type)
+    elif args.command == "extract-archive":
+        extract_archive(args.archive_path, args.folder_name)
+    elif args.command == "compress-folder":
+        compress_folder(args.folder_path, args.archive_format)
 
 
 if __name__ == "__main__":

--- a/src/Apps/Explorer/state/FileOperationsState.qml
+++ b/src/Apps/Explorer/state/FileOperationsState.qml
@@ -140,6 +140,56 @@ QtObject {
         var line = String(rawLine || "").trim()
         if (line === "")
             return
+        if (line[0] === "{") {
+            try {
+                var evt = JSON.parse(line)
+                var eventName = String(evt.event || "").toLowerCase()
+                if (eventName === "start") {
+                    fileOperationMode = String(evt.mode || fileOperationMode || "copy")
+                    fileOperationDestination = String(evt.destination || fileOperationDestination)
+                    fileOperationTotalCount = Number(evt.total || fileOperationTotalCount || 0)
+                    fileOperationDoneCount = 0
+                    fileOperationStatus = fileOperationMode === "move" ? "Movendo..." : "Copiando..."
+                    fileOperationPercent = 0
+                    fileOperationProgress = 0
+                    return
+                } else if (eventName === "progress") {
+                    fileOperationMode = String(evt.mode || fileOperationMode || "copy")
+                    fileOperationDoneCount = Number(evt.done || 0)
+                    fileOperationTotalCount = Number(evt.total || fileOperationTotalCount || 0)
+                    var jsonPercent = Number(evt.percent || 0)
+                    if (!isFinite(jsonPercent))
+                        jsonPercent = 0
+                    fileOperationPercent = Math.max(0, Math.min(100, Math.round(jsonPercent)))
+                    fileOperationProgress = fileOperationPercent / 100
+                    fileOperationFileName = String(evt.name || "")
+                    fileOperationStatus = (fileOperationMode === "move" ? "Movendo" : "Copiando") + "... " + fileOperationPercent + "%"
+                    return
+                } else if (eventName === "done") {
+                    fileOperationMode = String(evt.mode || fileOperationMode || "copy")
+                    fileOperationDestination = String(evt.destination || fileOperationDestination)
+                    fileOperationDoneCount = Number(evt.done || fileOperationDoneCount || 0)
+                    fileOperationTotalCount = Number(evt.total || fileOperationTotalCount || 0)
+                    var donePercent = Number(evt.percent || 100)
+                    if (!isFinite(donePercent))
+                        donePercent = 100
+                    fileOperationPercent = Math.max(0, Math.min(100, Math.round(donePercent)))
+                    fileOperationProgress = fileOperationPercent / 100
+                    fileOperationStatus = fileOperationMode === "move" ? "Movido" : "Copiado"
+                    fileOperationError = ""
+                    return
+                } else if (eventName === "error") {
+                    var code = String(evt.code || "")
+                    var message = String(evt.message || "")
+                    fileOperationError = message !== "" ? message : "Falha na operacao"
+                    if (code !== "")
+                        fileOperationError = fileOperationError + " (" + code + ")"
+                    fileOperationStatus = fileOperationError
+                    return
+                }
+            } catch (e) {
+            }
+        }
         var parts = line.split("|")
         if (parts[0] === "START") {
             fileOperationMode = parts[1] || fileOperationMode
@@ -199,43 +249,11 @@ QtObject {
         archiveExtractionTotalCount = 0
 
         archiveExtractProcess.command = [
-            "bash", "-lc",
-            "archive=\"$1\"; base=\"$2\"; parent=$(dirname -- \"$archive\"); archive_name=$(basename -- \"$archive\"); " +
-            "dest=\"$parent/$base\"; n=2; while [ -e \"$dest\" ]; do dest=\"$parent/$base $n\"; n=$((n+1)); done; " +
-            "mkdir -p -- \"$dest\" || exit 1; " +
-            "lower=$(printf '%s' \"$archive\" | tr '[:upper:]' '[:lower:]'); " +
-            "count_entries() { " +
-            "  if [[ \"$lower\" =~ \\.zip$ ]] && command -v unzip >/dev/null 2>&1; then unzip -Z1 \"$archive\" 2>/dev/null | wc -l; " +
-            "  elif [[ \"$lower\" =~ \\.rar$ ]] && command -v unrar >/dev/null 2>&1; then unrar lb \"$archive\" 2>/dev/null | wc -l; " +
-            "  elif [[ \"$lower\" =~ \\.(7z|rar)$ ]] && command -v 7z >/dev/null 2>&1; then 7z l -ba \"$archive\" 2>/dev/null | awk 'NF { c++ } END { print c + 0 }'; " +
-            "  elif command -v bsdtar >/dev/null 2>&1; then bsdtar -tf \"$archive\" 2>/dev/null | wc -l; " +
-            "  else printf '0\\n'; fi; " +
-            "}; " +
-            "extract_archive() { " +
-            "  if [[ \"$lower\" =~ \\.zip$ ]]; then " +
-            "    if command -v unzip >/dev/null 2>&1; then unzip -o \"$archive\" -d \"$dest\"; else bsdtar -xf \"$archive\" -C \"$dest\"; fi; " +
-            "  elif [[ \"$lower\" =~ \\.7z$ ]]; then " +
-            "    7z x -y -o\"$dest\" \"$archive\"; " +
-            "  elif [[ \"$lower\" =~ \\.rar$ ]]; then " +
-            "    if command -v unrar >/dev/null 2>&1; then unrar x -o+ \"$archive\" \"$dest/\"; else 7z x -y -o\"$dest\" \"$archive\"; fi; " +
-            "  else " +
-            "    bsdtar -xf \"$archive\" -C \"$dest\"; " +
-            "  fi; " +
-            "}; " +
-            "total=$(count_entries | tail -n1 | tr -dc '0-9'); total=${total:-0}; " +
-            "printf 'START|%s|%s|%s\\n' \"$archive_name\" \"$dest\" \"$total\"; " +
-            "log=$(mktemp); extract_archive >\"$log\" 2>&1 & pid=$!; tick=0; " +
-            "while kill -0 \"$pid\" 2>/dev/null; do " +
-            "  tick=$((tick + 1)); " +
-            "  done_count=$(find \"$dest\" -mindepth 1 2>/dev/null | wc -l | tr -dc '0-9'); done_count=${done_count:-0}; " +
-            "  if [ \"$total\" -gt 0 ] && [ \"$done_count\" -gt 0 ]; then pct=$((done_count * 100 / total)); [ \"$pct\" -gt 99 ] && pct=99; " +
-            "  else pct=$((tick * 3)); [ \"$pct\" -gt 95 ] && pct=95; fi; " +
-            "  printf 'PROGRESS|%s|%s|%s\\n' \"$done_count\" \"$total\" \"$pct\"; sleep 0.2; " +
-            "done; " +
-            "wait \"$pid\"; code=$?; rm -f -- \"$log\"; " +
-            "done_count=$(find \"$dest\" -mindepth 1 2>/dev/null | wc -l | tr -dc '0-9'); done_count=${done_count:-0}; " +
-            "if [ \"$code\" -eq 0 ]; then printf 'DONE|%s|%s|%s|100\\n' \"$dest\" \"$done_count\" \"$total\"; else printf 'ERROR|%s|%s\\n' \"$dest\" \"$code\"; fi; exit \"$code\"",
-            "_", archivePath, folderName || basename(archivePath)
+            "python3",
+            app.helperPath,
+            "extract-archive",
+            archivePath,
+            folderName || basename(archivePath)
         ]
         archiveExtractProcess.running = false
         archiveExtractProcess.running = true
@@ -259,41 +277,11 @@ QtObject {
         archiveExtractionTotalCount = 0
 
         archiveExtractProcess.command = [
-            "bash", "-lc",
-            "folder=\"$1\"; format=\"$2\"; " +
-            "[ -d \"$folder\" ] || { printf 'ERROR||not-dir\\n'; exit 1; }; " +
-            "parent=$(dirname -- \"$folder\"); name=$(basename -- \"$folder\"); " +
-            "case \"$format\" in " +
-            "  zip) ext='zip' ;; " +
-            "  rar) ext='rar' ;; " +
-            "  tar) ext='tar' ;; " +
-            "  tar.gz) ext='tar.gz' ;; " +
-            "  tar.xz) ext='tar.xz' ;; " +
-            "  *) printf 'ERROR||bad-format\\n'; exit 1 ;; " +
-            "esac; " +
-            "target=\"$parent/$name.$ext\"; n=2; while [ -e \"$target\" ]; do target=\"$parent/$name $n.$ext\"; n=$((n+1)); done; " +
-            "total=$(find \"$folder\" -mindepth 1 2>/dev/null | wc -l | tr -dc '0-9'); total=${total:-0}; " +
-            "printf 'START|%s|%s|%s\\n' \"$name\" \"$target\" \"$total\"; " +
-            "compress_archive() { " +
-            "  cd \"$parent\" || return 1; " +
-            "  case \"$format\" in " +
-            "    zip) command -v zip >/dev/null 2>&1 || return 127; zip -qr \"$target\" \"$name\" ;; " +
-            "    rar) command -v rar >/dev/null 2>&1 || return 127; rar a -idq \"$target\" \"$name\" ;; " +
-            "    tar) tar -cf \"$target\" -- \"$name\" ;; " +
-            "    tar.gz) tar -czf \"$target\" -- \"$name\" ;; " +
-            "    tar.xz) tar -cJf \"$target\" -- \"$name\" ;; " +
-            "  esac; " +
-            "}; " +
-            "compress_archive & pid=$!; tick=0; " +
-            "while kill -0 \"$pid\" 2>/dev/null; do " +
-            "  tick=$((tick + 1)); " +
-            "  pct=$((tick * 2)); [ \"$pct\" -gt 95 ] && pct=95; " +
-            "  done_count=0; [ \"$total\" -gt 0 ] && [ \"$pct\" -gt 0 ] && done_count=$(((total * pct + 99) / 100)); " +
-            "  printf 'PROGRESS|%s|%s|%s\\n' \"$done_count\" \"$total\" \"$pct\"; sleep 0.25; " +
-            "done; " +
-            "wait \"$pid\"; code=$?; " +
-            "if [ \"$code\" -eq 0 ]; then printf 'DONE|%s|%s|%s|100\\n' \"$target\" \"$total\" \"$total\"; else rm -f -- \"$target\"; printf 'ERROR|%s|%s\\n' \"$target\" \"$code\"; fi; exit \"$code\"",
-            "_", folderPath, format || "zip"
+            "python3",
+            app.helperPath,
+            "compress-folder",
+            folderPath,
+            format || "zip"
         ]
         archiveExtractProcess.running = false
         archiveExtractProcess.running = true
@@ -303,6 +291,51 @@ QtObject {
         var line = String(rawLine || "").trim()
         if (line === "")
             return
+        if (line[0] === "{") {
+            try {
+                var evt = JSON.parse(line)
+                var eventName = String(evt.event || "").toLowerCase()
+                if (eventName === "start") {
+                    archiveExtractionFileName = String(evt.name || archiveExtractionFileName)
+                    archiveExtractionDestination = String(evt.destination || archiveExtractionDestination)
+                    archiveExtractionTotalCount = Number(evt.total || archiveExtractionTotalCount || 0)
+                    archiveExtractionDoneCount = 0
+                    archiveExtractionPercent = 0
+                    archiveExtractionProgress = 0
+                    archiveExtractionStatus = archiveOperationMode === "compress" ? "Compactando..." : "Extraindo..."
+                    return
+                } else if (eventName === "progress") {
+                    archiveExtractionDoneCount = Number(evt.done || 0)
+                    archiveExtractionTotalCount = Number(evt.total || archiveExtractionTotalCount || 0)
+                    var p = Number(evt.percent || 0)
+                    if (!isFinite(p)) p = 0
+                    archiveExtractionPercent = Math.max(0, Math.min(100, Math.round(p)))
+                    archiveExtractionProgress = archiveExtractionPercent / 100
+                    var v = archiveOperationMode === "compress" ? "Compactando" : "Extraindo"
+                    archiveExtractionStatus = v + "... " + archiveExtractionPercent + "%"
+                    return
+                } else if (eventName === "done") {
+                    archiveExtractionDestination = String(evt.destination || archiveExtractionDestination)
+                    archiveExtractionRevealName = basename(archiveExtractionDestination)
+                    archiveExtractionDoneCount = Number(evt.done || archiveExtractionDoneCount || 0)
+                    archiveExtractionTotalCount = Number(evt.total || archiveExtractionTotalCount || 0)
+                    archiveExtractionPercent = 100
+                    archiveExtractionProgress = 1
+                    archiveExtractionStatus = archiveOperationMode === "compress" ? "Compactacao concluida" : "Extracao concluida"
+                    archiveExtractionError = ""
+                    return
+                } else if (eventName === "error") {
+                    var m = String(evt.message || "")
+                    var c = String(evt.code || "")
+                    archiveExtractionDestination = String(evt.destination || archiveExtractionDestination)
+                    archiveExtractionError = m !== "" ? m : (archiveOperationMode === "compress" ? "Falha ao compactar" : "Falha ao extrair")
+                    if (c !== "")
+                        archiveExtractionError = archiveExtractionError + " (" + c + ")"
+                    archiveExtractionStatus = archiveExtractionError
+                    return
+                }
+            } catch (e) {}
+        }
         var parts = line.split("|")
         if (parts[0] === "START") {
             archiveExtractionFileName = parts[1] || archiveExtractionFileName
@@ -385,7 +418,9 @@ QtObject {
             "python3",
             app.helperPath,
             "scan-conflicts",
-            resolvedDestination
+            resolvedDestination,
+            "--format",
+            "json"
         ].concat(files)
         pendingPasteFiles = files.slice()
         pendingPasteMode = mode || "copy"
@@ -425,27 +460,11 @@ QtObject {
             return
         pendingClipboardImageMime = mimeType
         pasteImageProcess.command = [
-            "bash", "-lc",
-            "set -e; " +
-            "dest_dir=\"$1\"; mime=\"$2\"; " +
-            "case \"$mime\" in " +
-            "  image/png) ext='png' ;; " +
-            "  image/jpeg) ext='jpg' ;; " +
-            "  image/webp) ext='webp' ;; " +
-            "  image/gif) ext='gif' ;; " +
-            "  image/bmp) ext='bmp' ;; " +
-            "  image/tiff) ext='tiff' ;; " +
-            "  image/x-portable-pixmap) ext='ppm' ;; " +
-            "  image/x-portable-graymap) ext='pgm' ;; " +
-            "  image/x-portable-bitmap) ext='pbm' ;; " +
-            "  *) ext='png' ;; " +
-            "esac; " +
-            "stamp=$(date +'%Y-%m-%d %H-%M-%S'); " +
-            "base=\"Pasted Image $stamp\"; target=\"$dest_dir/$base.$ext\"; n=2; " +
-            "while [ -e \"$target\" ]; do target=\"$dest_dir/$base $n.$ext\"; n=$((n+1)); done; " +
-            "wl-paste --no-newline --type \"$mime\" > \"$target\"; " +
-            "printf '%s\\n' \"$target\"",
-            "_", app.currentPath, mimeType
+            "python3",
+            app.helperPath,
+            "paste-image",
+            app.currentPath,
+            mimeType
         ]
         pasteImageProcess.running = false
         pasteImageProcess.running = true
@@ -462,6 +481,7 @@ QtObject {
         pasteProcess.command = [
             app.backendPath,
             "file-op",
+            "--json-events",
             mode,
             destinationPath,
             policy,
@@ -509,20 +529,11 @@ QtObject {
         var targets = selectedPathsInCurrentFolder()
         pendingDeleteTargets = targets.slice()
         deleteProcess.command = [
-            "bash", "-lc",
-            "trashDir=\"$1\"; infoDir=\"$2\"; shift 2; mkdir -p -- \"$trashDir\" \"$infoDir\"; " +
-            "encode_path() { " +
-            "  if command -v python3 >/dev/null 2>&1; then python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=\"/\"))' \"$1\"; else printf '%s' \"$1\"; fi; " +
-            "}; " +
-            "for target in \"$@\"; do " +
-            "[ -e \"$target\" ] || continue; " +
-            "name=$(basename -- \"$target\"); dest=\"$trashDir/$name\"; " +
-            "n=2; while [ -e \"$dest\" ]; do dest=\"$trashDir/$name $n\"; n=$((n+1)); done; " +
-            "trash_name=$(basename -- \"$dest\"); info=\"$infoDir/$trash_name.trashinfo\"; " +
-            "mv -- \"$target\" \"$dest\" || continue; " +
-            "{ printf '[Trash Info]\\nPath='; encode_path \"$target\"; printf '\\nDeletionDate=%s\\n' \"$(date +'%Y-%m-%dT%H:%M:%S')\"; } > \"$info\"; " +
-            "done",
-            "_", app.trashFilesPath, app.trashInfoPath
+            "python3",
+            app.helperPath,
+            "trash",
+            app.trashFilesPath,
+            app.trashInfoPath
         ].concat(targets)
         deleteProcess.running = false
         deleteProcess.running = true
@@ -534,28 +545,11 @@ QtObject {
         var targets = selectedPathsInCurrentFolder()
         pendingRestoreTargets = targets.slice()
         restoreProcess.command = [
-            "bash", "-lc",
-            "trashInfo=\"$1\"; fallbackDir=\"$2\"; shift 2; mkdir -p -- \"$fallbackDir\"; " +
-            "decode_path() { " +
-            "  if command -v python3 >/dev/null 2>&1; then python3 -c 'import sys, urllib.parse; print(urllib.parse.unquote(sys.argv[1]))' \"$1\"; else printf '%s' \"$1\"; fi; " +
-            "}; " +
-            "unique_target() { " +
-            "  dir=\"$1\"; name=\"$2\"; base=\"$name\"; ext=\"\"; " +
-            "  case \"$name\" in .*|*.) ;; *.*) base=\"${name%.*}\"; ext=\".${name##*.}\" ;; esac; " +
-            "  candidate=\"$dir/$name\"; n=2; " +
-            "  while [ -e \"$candidate\" ]; do candidate=\"$dir/$base $n$ext\"; n=$((n + 1)); done; " +
-            "  printf '%s\\n' \"$candidate\"; " +
-            "}; " +
-            "for trashed in \"$@\"; do " +
-            "[ -e \"$trashed\" ] || continue; " +
-            "trash_name=$(basename -- \"$trashed\"); info=\"$trashInfo/$trash_name.trashinfo\"; original=\"\"; " +
-            "if [ -f \"$info\" ]; then raw=$(sed -n 's/^Path=//p' \"$info\" | head -n1); [ -n \"$raw\" ] && original=$(decode_path \"$raw\"); fi; " +
-            "[ -n \"$original\" ] || original=\"$fallbackDir/$trash_name\"; " +
-            "dest_dir=$(dirname -- \"$original\"); dest_name=$(basename -- \"$original\"); mkdir -p -- \"$dest_dir\" || dest_dir=\"$fallbackDir\"; " +
-            "dest=$(unique_target \"$dest_dir\" \"$dest_name\"); " +
-            "mv -- \"$trashed\" \"$dest\" && rm -f -- \"$info\"; " +
-            "done",
-            "_", app.trashInfoPath, app.homePath
+            "python3",
+            app.helperPath,
+            "restore-trash",
+            app.trashInfoPath,
+            app.homePath
         ].concat(targets)
         restoreProcess.running = false
         restoreProcess.running = true
@@ -564,12 +558,11 @@ QtObject {
 
     function emptyTrash() {
         emptyTrashProcess.command = [
-            "bash", "-lc",
-            "trash_files=\"$1\"; trash_info=\"$2\"; " +
-            "mkdir -p -- \"$trash_files\" \"$trash_info\"; " +
-            "find \"$trash_files\" -mindepth 1 -maxdepth 1 -exec rm -rf -- {} + 2>/dev/null; " +
-            "find \"$trash_info\" -mindepth 1 -maxdepth 1 -exec rm -f -- {} + 2>/dev/null",
-            "_", app.trashFilesPath, app.trashInfoPath
+            "python3",
+            app.helperPath,
+            "empty-trash",
+            app.trashFilesPath,
+            app.trashInfoPath
         ]
         emptyTrashProcess.running = false
         emptyTrashProcess.running = true
@@ -695,7 +688,37 @@ QtObject {
         stdout: StdioCollector {
             id: conflictScanStdout
             onStreamFinished: {
-                var items = text.split("\n").map(function(line) { return line.trim() }).filter(Boolean)
+                var raw = (text || "").trim()
+                var parsedItems = []
+                if (raw !== "") {
+                    try {
+                        var parsed = JSON.parse(raw)
+                        if (Array.isArray(parsed))
+                            parsedItems = parsed
+                    } catch (e) {
+                        parsedItems = raw.split("\n").map(function(line) { return line.trim() }).filter(Boolean).map(function(name) {
+                            return { name: name, conflict_kind: "name-collision", supported_policies: ["skip", "overwrite", "keep-both", "rename"] }
+                        })
+                    }
+                }
+
+                var blocking = parsedItems.filter(function(item) {
+                    var kind = String(item.conflict_kind || "")
+                    return kind === "file-over-directory" || kind === "directory-over-file" || kind === "same-path"
+                })
+                if (blocking.length > 0) {
+                    ops.pendingPasteFiles = []
+                    ops.pendingPasteMode = ""
+                    ops.pendingPasteDestination = ""
+                    ops.pendingPasteRename = ""
+                    ops.fileOperationRunning = true
+                    ops.fileOperationError = "Conflito de tipo nao suportado para colagem"
+                    ops.fileOperationStatus = ops.fileOperationError
+                    fileOperationHideTimer.restart()
+                    return
+                }
+
+                var items = parsedItems.map(function(item) { return String(item.name || "") }).filter(Boolean)
                 ops.pasteConflictItems = items
                 if (items.length > 0) {
                     ops.pendingPasteRename = items.length === 1 ? items[0] : ""

--- a/src/Apps/Explorer/tests/test_explorer_helper.py
+++ b/src/Apps/Explorer/tests/test_explorer_helper.py
@@ -1,0 +1,226 @@
+import json
+import io
+import subprocess
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import explorer_helper as helper
+
+
+class ScanConflictsTests(unittest.TestCase):
+    def test_no_conflicts(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            src = root / "src"
+            dst = root / "dst"
+            src.mkdir(); dst.mkdir()
+            (src / "a.txt").write_text("a")
+            rec = helper._conflict_record(src / "a.txt", dst)
+            self.assertIsNone(rec)
+
+    def test_file_file_conflict(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            src = root / "src"; dst = root / "dst"
+            src.mkdir(); dst.mkdir()
+            (src / "a.txt").write_text("a")
+            (dst / "a.txt").write_text("b")
+            rec = helper._conflict_record(src / "a.txt", dst)
+            self.assertEqual(rec["conflict_kind"], "file-replace")
+
+    def test_dir_dir_conflict(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            src = root / "src"; dst = root / "dst"
+            src.mkdir(); dst.mkdir()
+            (src / "folder").mkdir(); (dst / "folder").mkdir()
+            rec = helper._conflict_record(src / "folder", dst)
+            self.assertEqual(rec["conflict_kind"], "directory-merge")
+
+    def test_file_dir_and_dir_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            src = root / "src"; dst = root / "dst"
+            src.mkdir(); dst.mkdir()
+            (src / "node").write_text("a")
+            (dst / "node").mkdir()
+            rec = helper._conflict_record(src / "node", dst)
+            self.assertEqual(rec["conflict_kind"], "file-over-directory")
+            (src / "node").unlink(); (src / "node").mkdir()
+            (dst / "node").rmdir(); (dst / "node").write_text("b")
+            rec2 = helper._conflict_record(src / "node", dst)
+            self.assertEqual(rec2["conflict_kind"], "directory-over-file")
+
+class TrashOpsTests(unittest.TestCase):
+    def test_trash_and_restore_with_collision_and_unicode(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            home = root / "home"
+            trash_files = home / ".local/share/Trash/files"
+            trash_info = home / ".local/share/Trash/info"
+            src_dir = home / "docs"
+            src_dir.mkdir(parents=True)
+
+            name = "a | ' 😀\n.txt"
+            source = src_dir / name
+            source.write_text("content", encoding="utf-8")
+
+            helper.trash_items(str(trash_files), str(trash_info), [str(source)])
+            self.assertFalse(source.exists())
+            trashed = list(trash_files.iterdir())
+            self.assertEqual(len(trashed), 1)
+            info = trash_info / f"{trashed[0].name}.trashinfo"
+            body = info.read_text(encoding="utf-8")
+            self.assertIn("[Trash Info]", body)
+            self.assertIn("Path=", body)
+            self.assertIn("DeletionDate=", body)
+
+            # force restore collision at original path
+            source.parent.mkdir(parents=True, exist_ok=True)
+            source.write_text("existing", encoding="utf-8")
+            helper.restore_trash_items(str(trash_info), str(home), [str(trashed[0])])
+            restored_candidates = list(source.parent.glob("a*txt"))
+            self.assertGreaterEqual(len(restored_candidates), 2)
+
+    def test_restore_without_trashinfo_falls_back(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            fallback = root / "fallback"
+            trash_files = root / "trash/files"
+            trash_info = root / "trash/info"
+            trash_files.mkdir(parents=True)
+            trash_info.mkdir(parents=True)
+            t = trash_files / "orphan.txt"
+            t.write_text("x")
+            helper.restore_trash_items(str(trash_info), str(fallback), [str(t)])
+            self.assertTrue((fallback / "orphan.txt").exists())
+
+    def test_empty_trash(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            trash_files = root / "trash/files"
+            trash_info = root / "trash/info"
+            (trash_files / "d").mkdir(parents=True)
+            (trash_files / "d" / "x.txt").write_text("x")
+            trash_info.mkdir(parents=True)
+            (trash_info / "x.trashinfo").write_text("meta")
+            helper.empty_trash(str(trash_files), str(trash_info))
+            self.assertEqual(list(trash_files.iterdir()), [])
+            self.assertEqual(list(trash_info.iterdir()), [])
+
+class PasteImageTests(unittest.TestCase):
+    def test_image_extension_mapping(self):
+        self.assertEqual(helper.image_extension_for_mime("image/png"), "png")
+        self.assertEqual(helper.image_extension_for_mime("image/jpeg"), "jpg")
+        self.assertEqual(helper.image_extension_for_mime("image/unknown"), "png")
+
+    def test_paste_image_writes_bytes_and_unique_name(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            dest = root / "dest 😀"
+            dest.mkdir()
+            fixed = "Pasted Image 2026-01-01 10-00-00"
+            (dest / f"{fixed}.png").write_bytes(b"old")
+
+            old = helper.time.strftime
+            helper.time.strftime = lambda _: "2026-01-01 10-00-00"
+            try:
+                def fake_runner(cmd, check, stdout, stderr):
+                    self.assertEqual(cmd[:3], ["wl-paste", "--no-newline", "--type"])
+                    self.assertEqual(cmd[3], "image/png")
+                    return subprocess.CompletedProcess(cmd, 0, stdout=b"image-bytes", stderr=b"")
+
+                out = helper.paste_image(str(dest), "image/png", paste_runner=fake_runner)
+            finally:
+                helper.time.strftime = old
+
+            path = Path(out)
+            self.assertTrue(path.exists())
+            self.assertEqual(path.read_bytes(), b"image-bytes")
+            self.assertTrue(path.name.startswith(fixed))
+            self.assertNotEqual(path.name, f"{fixed}.png")
+
+    def test_paste_image_unknown_mime_fallback_and_missing_dest(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            dest = root / "dest"
+            dest.mkdir()
+            created = helper.paste_image(
+                str(dest),
+                "image/custom",
+                paste_runner=lambda *args, **kwargs: subprocess.CompletedProcess([], 0, stdout=b"x", stderr=b""),
+            )
+            self.assertTrue(str(created).endswith(".png"))
+            with self.assertRaises(SystemExit):
+                helper.paste_image(str(root / "missing"), "image/png", paste_runner=lambda *a, **k: None)
+
+class ArchiveHelperTests(unittest.TestCase):
+    def test_extract_archive_emits_json_and_unique_destination(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            archive = root / "arquivo 😀.zip"
+            archive.write_bytes(b"x")
+            (root / "out").mkdir()
+            (root / "out 2").mkdir()
+
+            calls = []
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                helper.extract_archive(
+                    str(archive),
+                    "out",
+                    run_cmd=lambda cmd, **kwargs: calls.append(cmd) or subprocess.CompletedProcess(cmd, 0, b"", b""),
+                    which_runner=lambda name: "/usr/bin/" + name if name in ("unzip", "tar", "bsdtar") else None,
+                )
+            lines = [json.loads(line) for line in buf.getvalue().splitlines() if line.strip()]
+            self.assertEqual(lines[0]["event"], "start")
+            self.assertEqual(lines[-1]["event"], "done")
+            self.assertTrue(lines[0]["destination"].endswith("out 3"))
+            self.assertEqual(lines[-1]["percent"], 100)
+            self.assertTrue(calls)
+
+    def test_compress_folder_invalid_format_and_missing_tool(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            folder = root / "pasta"
+            folder.mkdir()
+            buf = io.StringIO()
+            with self.assertRaises(SystemExit):
+                with redirect_stdout(buf):
+                    helper.compress_folder(str(folder), "bad", run_cmd=lambda *a, **k: None)
+            err = json.loads(buf.getvalue().splitlines()[-1])
+            self.assertEqual(err["code"], "invalid_format")
+
+            buf2 = io.StringIO()
+            with self.assertRaises(SystemExit):
+                with redirect_stdout(buf2):
+                    helper.compress_folder(str(folder), "zip", run_cmd=lambda *a, **k: None, which_runner=lambda _: None)
+            err2 = json.loads(buf2.getvalue().splitlines()[-1])
+            self.assertEqual(err2["code"], "missing_tool")
+
+    def test_extract_7z_uses_joined_output_flag(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            archive = root / "x.7z"
+            archive.write_bytes(b"x")
+            captured = {}
+
+            def fake_run(cmd, **kwargs):
+                captured["cmd"] = cmd
+                return subprocess.CompletedProcess(cmd, 0, b"", b"")
+
+            helper.extract_archive(
+                str(archive),
+                "dest",
+                run_cmd=fake_run,
+                which_runner=lambda name: "/usr/bin/7z" if name == "7z" else None,
+            )
+            self.assertTrue(any(part.startswith("-o") and len(part) > 2 for part in captured["cmd"]))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Core/bridge/apps/explorer/src/file_ops.rs
+++ b/src/Core/bridge/apps/explorer/src/file_ops.rs
@@ -27,17 +27,28 @@ enum ConflictPolicy {
     KeepBoth,
 }
 
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum EventFormat {
+    Legacy,
+    Jsonl,
+}
+
 pub fn run(args: &[String]) -> Result<(), String> {
-    match run_inner(args) {
+    let (format, normalized_args) = parse_event_format(args);
+    match run_inner(&normalized_args, format) {
         Ok(()) => Ok(()),
-        Err(err) => {
-            emit_file_op_event("ERROR", &[err.clone()]);
-            Err(err)
-        }
+        Err(err) => Err(err),
     }
 }
 
-fn run_inner(args: &[String]) -> Result<(), String> {
+fn parse_event_format(args: &[String]) -> (EventFormat, Vec<String>) {
+    if args.first().map(String::as_str) == Some("--json-events") {
+        return (EventFormat::Jsonl, args[1..].to_vec());
+    }
+    (EventFormat::Legacy, args.to_vec())
+}
+
+fn run_inner(args: &[String], format: EventFormat) -> Result<(), String> {
     if args.len() < 5 {
         return Err("usage: explorer_backend file-op <copy|move|cut> <destination> <overwrite|skip|rename|keep-both> <rename> <paths...>".into());
     }
@@ -57,14 +68,7 @@ fn run_inner(args: &[String]) -> Result<(), String> {
         ));
     }
 
-    emit_file_op_event(
-        "START",
-        &[
-            mode.as_str().to_string(),
-            destination.to_string_lossy().into_owned(),
-            sources.len().to_string(),
-        ],
-    );
+    emit_file_op_start(format, mode, destination, sources.len());
 
     let mut completed = 0usize;
     for source in &sources {
@@ -81,13 +85,13 @@ fn run_inner(args: &[String]) -> Result<(), String> {
 
         if same_path(source, &initial_target) {
             completed += 1;
-            emit_file_op_progress(completed, sources.len(), source);
+            emit_file_op_progress(format, mode, completed, sources.len(), source);
             continue;
         }
 
         let Some(target) = resolve_conflict_target(&initial_target, policy)? else {
             completed += 1;
-            emit_file_op_progress(completed, sources.len(), source);
+            emit_file_op_progress(format, mode, completed, sources.len(), source);
             continue;
         };
 
@@ -95,20 +99,22 @@ fn run_inner(args: &[String]) -> Result<(), String> {
             fs::create_dir_all(parent).map_err(|e| format!("create {}: {e}", parent.display()))?;
         }
 
-        run_operation(mode, source, &target, policy == ConflictPolicy::Overwrite)?;
+        if let Err(err) = run_operation(mode, source, &target, policy == ConflictPolicy::Overwrite) {
+            emit_file_op_error(
+                format,
+                classify_error_code(&err),
+                &err,
+                Some(mode),
+                Some(source),
+            );
+            return Err(err);
+        }
 
         completed += 1;
-        emit_file_op_progress(completed, sources.len(), source);
+        emit_file_op_progress(format, mode, completed, sources.len(), source);
     }
 
-    emit_file_op_event(
-        "DONE",
-        &[
-            destination.to_string_lossy().into_owned(),
-            completed.to_string(),
-            sources.len().to_string(),
-        ],
-    );
+    emit_file_op_done(format, mode, destination, completed, sources.len());
     Ok(())
 }
 
@@ -156,26 +162,35 @@ fn run_operation(
     }
 }
 
-fn emit_file_op_progress(done: usize, total: usize, source: &Path) {
-    let percent = if total == 0 {
-        100
-    } else {
-        done.saturating_mul(100) / total
-    };
+fn clamped_percent(done: usize, total: usize) -> usize {
+    let raw = if total == 0 { 100 } else { done.saturating_mul(100) / total };
+    raw.clamp(0, 100)
+}
+
+fn emit_file_op_progress(format: EventFormat, mode: OperationMode, done: usize, total: usize, source: &Path) {
+    let percent = clamped_percent(done, total);
     let name = source
         .file_name()
         .and_then(|v| v.to_str())
         .unwrap_or_default()
         .to_string();
-    emit_file_op_event(
-        "PROGRESS",
-        &[
-            done.to_string(),
-            total.to_string(),
-            percent.to_string(),
-            name,
-        ],
-    );
+    let source_path = source.to_string_lossy().into_owned();
+    match format {
+        EventFormat::Legacy => emit_file_op_event(
+            "PROGRESS",
+            &[
+                done.to_string(),
+                total.to_string(),
+                percent.to_string(),
+                name,
+            ],
+        ),
+        EventFormat::Jsonl => println!(
+            "{}",
+            json_progress_line(mode, done, total, percent, &source_path, &name)
+        ),
+    }
+    flush_stdout();
 }
 
 fn emit_file_op_event(event: &str, fields: &[String]) {
@@ -185,7 +200,115 @@ fn emit_file_op_event(event: &str, fields: &[String]) {
         line.push_str(&sanitize_pipe_field(field));
     }
     println!("{line}");
+}
+
+fn emit_file_op_start(format: EventFormat, mode: OperationMode, destination: &Path, total: usize) {
+    let destination = destination.to_string_lossy().into_owned();
+    match format {
+        EventFormat::Legacy => emit_file_op_event("START", &[mode.as_str().to_string(), destination, total.to_string()]),
+        EventFormat::Jsonl => println!(
+            "{}",
+            json_start_line(mode, &destination, total)
+        ),
+    }
     flush_stdout();
+}
+
+fn emit_file_op_done(format: EventFormat, mode: OperationMode, destination: &Path, done: usize, total: usize) {
+    let destination = destination.to_string_lossy().into_owned();
+    let percent = clamped_percent(done, total);
+    match format {
+        EventFormat::Legacy => emit_file_op_event("DONE", &[destination, done.to_string(), total.to_string()]),
+        EventFormat::Jsonl => println!(
+            "{}",
+            json_done_line(mode, &destination, done, total, percent)
+        ),
+    }
+    flush_stdout();
+}
+
+fn emit_file_op_error(format: EventFormat, code: &str, message: &str, mode: Option<OperationMode>, path: Option<&Path>) {
+    match format {
+        EventFormat::Legacy => emit_file_op_event("ERROR", &[message.to_string()]),
+        EventFormat::Jsonl => {
+            let mode_json = mode.map(|m| format!(",\"mode\":\"{}\"", m.as_str())).unwrap_or_default();
+            let path_json = path.map(|p| format!(",\"path\":\"{}\"", escape_json(&p.to_string_lossy()))).unwrap_or_default();
+            println!(
+                "{}",
+                json_error_line(mode_json, code, message, path_json)
+            );
+        }
+    }
+    flush_stdout();
+}
+
+fn classify_error_code(message: &str) -> &'static str {
+    let m = message.to_ascii_lowercase();
+    if m.contains("permission denied") {
+        "permission_denied"
+    } else if m.contains("not found") || m.contains("no such file") {
+        "not_found"
+    } else if m.contains("already exists") {
+        "already_exists"
+    } else if m.contains("invalid") {
+        "invalid_path"
+    } else {
+        "operation_failed"
+    }
+}
+fn json_start_line(mode: OperationMode, destination: &str, total: usize) -> String {
+    format!(
+        "{{\"event\":\"start\",\"mode\":\"{}\",\"destination\":\"{}\",\"total\":{}}}",
+        mode.as_str(),
+        escape_json(destination),
+        total
+    )
+}
+fn json_progress_line(mode: OperationMode, done: usize, total: usize, percent: usize, path: &str, name: &str) -> String {
+    format!(
+        "{{\"event\":\"progress\",\"mode\":\"{}\",\"done\":{},\"total\":{},\"percent\":{},\"path\":\"{}\",\"name\":\"{}\"}}",
+        mode.as_str(),
+        done,
+        total,
+        percent.clamp(0, 100),
+        escape_json(path),
+        escape_json(name)
+    )
+}
+fn json_done_line(mode: OperationMode, destination: &str, done: usize, total: usize, percent: usize) -> String {
+    format!(
+        "{{\"event\":\"done\",\"mode\":\"{}\",\"destination\":\"{}\",\"done\":{},\"total\":{},\"percent\":{}}}",
+        mode.as_str(),
+        escape_json(destination),
+        done,
+        total,
+        percent.clamp(0, 100)
+    )
+}
+fn json_error_line(mode_json: String, code: &str, message: &str, path_json: String) -> String {
+    format!(
+        "{{\"event\":\"error\"{},\"code\":\"{}\",\"message\":\"{}\"{}}}",
+        mode_json,
+        escape_json(code),
+        escape_json(message),
+        path_json
+    )
+}
+
+fn escape_json(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 8);
+    for c in value.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if c.is_control() => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
 }
 
 fn flush_stdout() {
@@ -444,4 +567,44 @@ fn is_self_or_descendant_target(source: &Path, target: &Path) -> bool {
     };
 
     target_canon == source_canon || target_canon.starts_with(&source_canon)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_lines_escape_special_names() {
+        let name = "a|b \"ç\" 😀\nline.txt";
+        let line = json_progress_line(OperationMode::Copy, 1, 3, 33, "/tmp/a|b\nx", name);
+        assert!(line.contains("\"event\":\"progress\""));
+        assert!(line.contains("\\n"));
+        assert!(line.contains("\\\"ç\\\""));
+        assert!(line.contains("😀"));
+    }
+
+    #[test]
+    fn percent_is_clamped() {
+        assert_eq!(clamped_percent(300, 1), 100);
+        let line = json_done_line(OperationMode::Move, "/tmp", 3, 2, 150);
+        assert!(line.contains("\"percent\":100"));
+    }
+
+    #[test]
+    fn error_event_shape_contains_code_and_message() {
+        let line = json_error_line(",\"mode\":\"copy\"".to_string(), "permission_denied", "denied", ",\"path\":\"/tmp/x\"".to_string());
+        assert!(line.contains("\"event\":\"error\""));
+        assert!(line.contains("\"code\":\"permission_denied\""));
+        assert!(line.contains("\"message\":\"denied\""));
+        assert!(line.contains("\"path\":\"/tmp/x\""));
+    }
+
+    #[test]
+    fn classify_error_code_maps_common_errors() {
+        assert_eq!(classify_error_code("Permission denied: /tmp/a"), "permission_denied");
+        assert_eq!(classify_error_code("No such file or directory"), "not_found");
+        assert_eq!(classify_error_code("already exists"), "already_exists");
+        assert_eq!(classify_error_code("invalid source path"), "invalid_path");
+        assert_eq!(classify_error_code("something else"), "operation_failed");
+    }
 }


### PR DESCRIPTION
### Motivation

- Provide robust file operation tooling for the Explorer app with structured JSON events and helper utilities for paste-image, archive extract/compress, and trash management. 
- Replace complex inline shell snippets in QML with a single Python helper to improve portability, testability and encoding handling. 
- Improve the bridge `file-op` output to support a machine-readable JSONL mode for better UI feedback and error classification.

### Description

- Introduce `src/Apps/Explorer/explorer_helper.py` implementing `paste_image`, `extract_archive`, `compress_folder`, trash operations (`trash_items`, `restore_trash_items`, `empty_trash`), improved conflict scanning and helpers like `_unique_target`, URL encoding/decoding, and JSON event emission. 
- Update the QML state (`FileOperationsState.qml`) to call the helper for `paste-image`, `extract-archive`, `compress-folder`, `trash`/`restore-trash`/`empty-trash` and to parse JSON events for both file operations and archive operations; also request `scan-conflicts` in JSON format. 
- Add JSONL output support to Rust bridge `file_ops.rs` behind a new `--json-events` flag, with structured `start`, `progress`, `done`, and `error` events, safer percent clamping and error code classification, JSON escaping utilities, and unit tests. 
- Add unit tests in `src/Apps/Explorer/tests/test_explorer_helper.py` covering conflict scanning, trash restore semantics, paste-image behavior, and archive compress/extract behaviors. 
- Add `RELIABILITY_MANUAL_CHECKLIST.md` for Explorer and update `scripts/run_refactor_checks.sh` to run the new Python unit test and the Rust tests for the explorer bridge.

### Testing

- Ran the new Python unit test `python3 -m unittest src/Apps/Explorer/tests/test_explorer_helper.py`, which succeeded. 
- Ran the explorer bridge Rust tests with `cargo test -q` under `src/Core/bridge/apps/explorer`, which succeeded. 
- Updated `scripts/run_refactor_checks.sh` to include the new Python test and the Rust tests so the same checks run in the refactor pipeline.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d967a43888326a02c3215e3684c36)